### PR TITLE
update japanese(ja) translation

### DIFF
--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -1,65 +1,65 @@
 'language:ja':
   ba-videoplayer-playbutton.tooltip: クリックして再生します。
-  ba-videoplayer-playbutton.rerecord: やり直し
+  ba-videoplayer-playbutton.rerecord: 再録画
   ba-videoplayer-playbutton.submit-video: ビデオを確認する
   ba-videoplayer-loader.tooltip: 読み込んでいます...
   ba-videoplayer-controlbar.change-resolution: 解像度を変更する
   ba-videoplayer-controlbar.video-progress: 進捗
-  ba-videoplayer-controlbar.rerecord-video: やり直し？
+  ba-videoplayer-controlbar.rerecord-video: 再録画？
   ba-videoplayer-controlbar.submit-video: 確認
-  ba-videoplayer-controlbar.play-video: 演奏する
+  ba-videoplayer-controlbar.play-video: 再生する
   ba-videoplayer-controlbar.pause-video: 一時停止
   ba-videoplayer-controlbar.elapsed-time: 経過時間
-  ba-videoplayer-controlbar.total-time: の全長
-  ba-videoplayer-controlbar.fullscreen-video: フルスクリーンに入る
+  ba-videoplayer-controlbar.total-time: 合計時間
+  ba-videoplayer-controlbar.fullscreen-video: 全画面表示にする
   ba-videoplayer-controlbar.volume-button: ボリュームを設定する
-  ba-videoplayer-controlbar.volume-mute: ミュート音
-  ba-videoplayer-controlbar.volume-unmute: ミュート解除サウンド
+  ba-videoplayer-controlbar.volume-mute: ミュート
+  ba-videoplayer-controlbar.volume-unmute: ミュート解除
   ba-videoplayer.video-error: エラーが発生しました。しばらくしてからもう一度お試しください。クリックして再試行します。
-  ba-videorecorder-chooser.record-video: 録画映像
-  ba-videorecorder-chooser.upload-video: ビデオのアップロード
+  ba-videorecorder-chooser.record-video: 録画
+  ba-videorecorder-chooser.upload-video: 動画アップロード
   ba-videorecorder-controlbar.settings: 設定
-  ba-videorecorder-controlbar.camerahealthy: 照明は良いです
+  ba-videorecorder-controlbar.camerahealthy: 照明は良好です
   ba-videorecorder-controlbar.cameraunhealthy: 照明が最適ではありません
-  ba-videorecorder-controlbar.microphonehealthy: 音がいい
-  ba-videorecorder-controlbar.microphoneunhealthy: 音が出ない
-  ba-videorecorder-controlbar.record: 記録
-  ba-videorecorder-controlbar.record-tooltip: 録音するにはここをクリックしてください。
-  ba-videorecorder-controlbar.rerecord: やり直し
-  ba-videorecorder-controlbar.rerecord-tooltip: やり直すには、ここをクリックしてください。
+  ba-videorecorder-controlbar.microphonehealthy: 音声は良好です
+  ba-videorecorder-controlbar.microphoneunhealthy: 音声を認識できません
+  ba-videorecorder-controlbar.record: 録画開始
+  ba-videorecorder-controlbar.record-tooltip: 録画開始するにはここをクリックしてください。
+  ba-videorecorder-controlbar.rerecord: 再録画
+  ba-videorecorder-controlbar.rerecord-tooltip: 再録画するには、ここをクリックしてください。
   ba-videorecorder-controlbar.upload-covershot: カバーをアップロード
   ba-videorecorder-controlbar.upload-covershot-tooltip: カスタムカバーショットをアップロードするには、ここをクリックしてください
-  ba-videorecorder-controlbar.stop: やめる
+  ba-videorecorder-controlbar.stop: 停止
   ba-videorecorder-controlbar.stop-tooltip: 停止するには、ここをクリックしてください。
   ba-videorecorder-controlbar.skip: スキップ
   ba-videorecorder-controlbar.skip-tooltip: スキップするには、ここをクリックしてください。
   ba-videorecorder.recorder-error: エラーが発生しました。しばらくしてからもう一度お試しください。クリックして再試行します。
   ba-videorecorder.attach-error: >-
     メディアインターフェイスにアクセスできませんでした。デバイスとブラウザによっては、Flashをインストールするか、SSL経由でページにアクセスする必要がある場合があります。
-  ba-videorecorder.access-forbidden: メディアへのアクセスは禁止されていました。クリックして再試行します。
+  ba-videorecorder.access-forbidden: メディアへのアクセスができません。クリックして再試行します。
   ba-videorecorder.pick-covershot: カバーショットを選んでください。
   ba-videorecorder.uploading: アップロード
   ba-videorecorder.uploading-failed: アップロードに失敗しました-ここをクリックして再試行してください。
-  ba-videorecorder.verifying: 確認中
-  ba-videorecorder.verifying-failed: 確認に失敗しました-ここをクリックして再試行してください。
-  ba-videorecorder.rerecord-confirm: あなたは本当にあなたのビデオをやり直したいですか？
-  ba-videorecorder.video_file_too_large: ビデオファイルが大きすぎます（％s）-ここをクリックして、小さいビデオファイルで再試行してください。
-  ba-videorecorder.unsupported_video_type: アップロードしてください：％s-ここをクリックして再試行してください。
-  ba-videoplayer-controlbar.exit-fullscreen-video: フルスクリーンで終了
+  ba-videorecorder.verifying: 検証中
+  ba-videorecorder.verifying-failed: 検証に失敗しました-ここをクリックして再試行してください。
+  ba-videorecorder.rerecord-confirm: 本当に再録画しますか？
+  ba-videorecorder.video_file_too_large: ビデオファイルが大きすぎます(%s)-ここをクリックして、小さいビデオファイルで再試行してください。
+  ba-videorecorder.unsupported_video_type: アップロードしてください：%s -ここをクリックして再試行してください。
+  ba-videoplayer-controlbar.exit-fullscreen-video: 全画面表示を終了
   ba-videoplayer-share.share: メディアを共有する
-  ba-videorecorder-chooser.record-screen: 記録画面
+  ba-videorecorder-chooser.record-screen: 画面録画
   ba-videoplayer-controlbar.pause-video-disabled: 一時停止はサポートされていません
   ba-videorecorder-chooser.record-audio: レコードオーディオ
-  ba-videorecorder-controlbar.stop-available-after: 最小記録時間は％d秒です
+  ba-videorecorder-controlbar.stop-available-after: 最短でも%d秒は録画が必要です
   ba-videorecorder-controlbar.cancel: キャンセル
   ba-videorecorder-controlbar.cancel-tooltip: キャンセルするには、ここをクリックしてください。
   ba-videorecorder.cancel-confirm: ビデオのアップロードを本当にキャンセルしますか？
   ba-videoplayer-adslot.elapsed-time: 経過時間
   ba-videoplayer-adslot.volume-button: ボリュームを設定する
-  ba-videoplayer-adslot.volume-mute: ミュート音
-  ba-videoplayer-adslot.volume-unmute: ミュート解除サウンド
-  ba-videoplayer-adslot.ad-will-end-after: 広告は％s後に終了します
-  ba-videoplayer-adslot.can-skip-after: ％dの後にスキップ
+  ba-videoplayer-adslot.volume-mute: ミュート
+  ba-videoplayer-adslot.volume-unmute: ミュート解除
+  ba-videoplayer-adslot.ad-will-end-after: 広告は%s後に終了します
+  ba-videoplayer-adslot.can-skip-after: (%d)の後にスキップ
   ba-videoplayer-adslot.skip-ad: 広告をスキップ
   ba-videorecorder.software-required: 続行するには、以下をクリックして次の要件をインストール/アクティブ化してください。
   ba-videorecorder.software-waiting: 要件がインストール/アクティブ化されるのを待っています。完了後にページを更新する必要がある場合があります。
@@ -77,13 +77,13 @@
   ba-videorecorder.orientation-landscape-required: 横向きモードで記録するには、デバイスを回転させてください。
   ba-imageviewer-controlbar.rerecord-image: やり直し？
   ba-imageviewer-controlbar.submit-image: 確認
-  ba-imageviewer-controlbar.fullscreen-image: フルスクリーンに入る
-  ba-imageviewer-controlbar.exit-fullscreen-image: フルスクリーンで終了
+  ba-imageviewer-controlbar.fullscreen-image: 全画面表示にする
+  ba-imageviewer-controlbar.exit-fullscreen-image: 全画面表示を終了
   ba-imageviewer.image-error: エラーが発生しました。しばらくしてからもう一度お試しください。クリックして再試行します。
   ba-imagecapture-chooser.image-capture: 画像をキャプチャする
   ba-imagecapture-chooser.upload-image: 画像をアップロード
   ba-imagecapture-controlbar.settings: 設定
-  ba-imagecapture-controlbar.camerahealthy: 照明は良いです
+  ba-imagecapture-controlbar.camerahealthy: 照明は良好です
   ba-imagecapture-controlbar.cameraunhealthy: 照明が最適ではありません
   ba-imagecapture-controlbar.record: キャプチャー
   ba-imagecapture-controlbar.record-tooltip: キャプチャするには、ここをクリックしてください。
@@ -100,30 +100,30 @@
   ba-audioplayer-controlbar.elapsed-time: 経過時間
   ba-audioplayer-controlbar.total-time: の全長
   ba-audioplayer-controlbar.volume-button: ボリュームを設定する
-  ba-audioplayer-controlbar.volume-mute: ミュート音
-  ba-audioplayer-controlbar.volume-unmute: ミュート解除サウンド
+  ba-audioplayer-controlbar.volume-mute: ミュート
+  ba-audioplayer-controlbar.volume-unmute: ミュート解除
   ba-audioplayer-loader.tooltip: 読み込んでいます...
   ba-audioplayer.audio-error: エラーが発生しました。しばらくしてからもう一度お試しください。クリックして再試行します。
   ba-audiorecorder-chooser.record-audio: レコードオーディオ
   ba-audiorecorder-chooser.upload-audio: オーディオのアップロード
   ba-audiorecorder-controlbar.settings: 設定
-  ba-audiorecorder-controlbar.microphonehealthy: 音がいい
-  ba-audiorecorder-controlbar.microphoneunhealthy: 音が出ない
-  ba-audiorecorder-controlbar.record: 記録
+  ba-audiorecorder-controlbar.microphonehealthy: 音声は良好です
+  ba-audiorecorder-controlbar.microphoneunhealthy: 音声を認識できません
+  ba-audiorecorder-controlbar.record: 録音
   ba-audiorecorder-controlbar.record-tooltip: 録音するにはここをクリックしてください。
   ba-audiorecorder-controlbar.rerecord: やり直し
   ba-audiorecorder-controlbar.rerecord-tooltip: やり直すには、ここをクリックしてください。
-  ba-audiorecorder-controlbar.stop: やめる
+  ba-audiorecorder-controlbar.stop: 停止
   ba-audiorecorder-controlbar.stop-tooltip: 停止するには、ここをクリックしてください。
-  ba-audiorecorder-controlbar.stop-available-after: 最小記録時間は％d秒です
+  ba-audiorecorder-controlbar.stop-available-after: 最短でも%d秒は録音が必要です
   ba-audiorecorder-controlbar.cancel: キャンセル
   ba-audiorecorder-controlbar.cancel-tooltip: キャンセルするには、ここをクリックしてください。
-  ba-videoplayer-controlbar.player-speed: プレイヤーの速度
+  ba-videoplayer-controlbar.player-speed: 再生速度
   ba-videoplayer-controlbar.settings: 設定
   ba-videoplayer-controlbar.airplay: Airplay
   ba-videoplayer-controlbar.airplay-icon: Airplayアイコン。
   ba-videoplayer.all-settings: すべての設定
-  ba-videoplayer.player-speed: プレイヤーの速度
+  ba-videoplayer.player-speed: 再生速度
   ba-videoplayer.full-screen: 全画面表示
   ba-videorecorder-controlbar.add-stream: ストリームを追加
   ba-videorecorder.switch-camera: カメラを切り替える
@@ -143,8 +143,8 @@
   ba-imagecapture.verifying: 確認中
   ba-imagecapture.verifying-failed: 確認に失敗しました-ここをクリックして再試行してください。
   ba-imagecapture.rerecord-confirm: 本当に自分の画像を撮り直したいですか？
-  ba-imagecapture.image_file_too_large: 画像ファイルが大きすぎます（％s）-ここをクリックして、小さい画像ファイルで再試行してください。
-  ba-imagecapture.unsupported_image_type: アップロードしてください：％s-ここをクリックして再試行してください。
+  ba-imagecapture.image_file_too_large: 画像ファイルが大きすぎます（%s）-ここをクリックして、小さい画像ファイルで再試行してください。
+  ba-imagecapture.unsupported_image_type: アップロードしてください：%s-ここをクリックして再試行してください。
   ba-imagecapture.orientation-portrait-required: ポートレートモードで記録するには、デバイスを回転させてください。
   ba-imagecapture.orientation-landscape-required: 横向きモードで記録するには、デバイスを回転させてください。
   ba-audiorecorder.recorder-error: エラーが発生しました。しばらくしてからもう一度お試しください。クリックして再試行します。
@@ -160,21 +160,21 @@
   ba-audiorecorder.verifying-failed: 確認に失敗しました-ここをクリックして再試行してください。
   ba-audiorecorder.rerecord-confirm: 本当にオーディオをやり直したいですか？
   ba-audiorecorder.cancel-confirm: 本当にオーディオのアップロードをキャンセルしますか？
-  ba-audiorecorder.audio_file_too_large: オーディオファイルが大きすぎます（％s）-ここをクリックして、小さいオーディオファイルで再試行してください。
-  ba-audiorecorder.unsupported_audio_type: アップロードしてください：％s-ここをクリックして再試行してください。
+  ba-audiorecorder.audio_file_too_large: オーディオファイルが大きすぎます（%s）-ここをクリックして、小さいオーディオファイルで再試行してください。
+  ba-audiorecorder.unsupported_audio_type: アップロードしてください：%s-ここをクリックして再試行してください。
   ba-common-settingsmenu.tooltip: クリックして再生します。
   ba-common-settingsmenu.setting-menu: すべての設定
   ba-common-settingsmenu.source-quality: ソース品質
-  ba-common-settingsmenu.player-speed: プレイヤーの速度
+  ba-common-settingsmenu.player-speed: 再生速度
   ba-common-settingsmenu.set-menu-option: オプションを設定
   ba-common-settingsmenu.submit-video: ビデオを確認する
   ba-common-settingsmenu.picture-in-picture: ピクチャーインピクチャー
-  ba-common-settingsmenu.exit-fullscreen-video: フルスクリーンで終了
-  ba-common-settingsmenu.fullscreen-video: フルスクリーンに入る
+  ba-common-settingsmenu.exit-fullscreen-video: 全画面表示を終了
+  ba-common-settingsmenu.fullscreen-video: 全画面表示にする
   ba-videorecorder-chooser.multi-stream: マルチストリーム
   ba-videorecorder-controlbar.pause-recorder: レコーダーの一時停止
   ba-videorecorder-controlbar.resume-recorder: レジュメレコーダー
   ba-videorecorder.missing-track: 必要なオーディオまたはビデオトラックがありません
   ba-videorecorder.device-already-in-use: 入力デバイスの少なくとも1つがすでに使用されています
-  ba-videorecorder.browser-permission-denied: ブラウザによって許可が拒否されました。アクセスを許可してページをリロードしてください
+  ba-videorecorder.browser-permission-denied: ブラウザによって拒否されました。アクセスを許可してページをリロードしてください
   ba-audioplayer.all-settings: すべての設定


### PR DESCRIPTION
I updated the Japanese(ja) translation as part of #127

When machine translating from half width to full width, the% was changed and the variable part of the message was not working.I've fixed Japanese, but it may be better to check if there are any problems with other languages.
<img width="394" alt="スクリーンショット 2020-11-22 22 57 25" src="https://user-images.githubusercontent.com/9640392/99906290-96101200-2d19-11eb-8f21-cc3c35c2429c.png">
