### PR TITLE
Feature: pickcovershotframe

### DIFF
--- a/src/dynamics/video_player/controlbar/video_player_controlbar.html
+++ b/src/dynamics/video_player/controlbar/video_player_controlbar.html
@@ -98,6 +98,15 @@
             </p>
         </div>
 
+        <div tabindex="12" class="{{css}}-rightbutton-container" ba-if="{{frameselectionmode}}">
+        	<div data-selector="select-frame-button"
+                 onmouseout="this.blur()"
+                 ba-click="{{select_frame()}}"
+                 class="{{css}}-rerecord-button">
+                 {{string('select-frame')}}
+        	</div>
+        </div>
+
         <div tabindex="11" data-selector="button-icon-settings"
              ba-hotkey:space^enter="{{toggle_settings_menu()}}" onmouseout="this.blur()"
              class="{{css}}-rightbutton-container {{cssplayer}}-button-{{settingsmenuactive ? 'active' : 'inactive'}}"

--- a/src/dynamics/video_player/player/player.html
+++ b/src/dynamics/video_player/player/player.html
@@ -75,6 +75,7 @@
             ba-hidebarafter="{{hidebarafter}}"
             ba-rerecordable="{{rerecordable}}"
             ba-submittable="{{submittable}}"
+            ba-frameselectionmode="{{frameselectionmode}}"
             ba-streams="{{streams}}"
             ba-currentstream="{{=currentstream}}"
             ba-fullscreen="{{fullscreensupport && !nofullscreen}}"

--- a/src/dynamics/video_recorder/recorder/recorder.html
+++ b/src/dynamics/video_recorder/recorder/recorder.html
@@ -182,6 +182,7 @@
 		ba-tracksshowselection="{{tracksshowselection}}"
 		ba-trackselectorhovered="{{trackselectorhovered}}"
 		ba-uploadlocales="{{uploadlocales}}"
+		ba-frameselectionmode="{{frameselectionmode}}"
 		ba-event:selected_label_value="selected_label_value"
 		ba-event:move_to_option="move_to_option"
 	>

--- a/src/dynamics/video_recorder/recorder/recorder.html
+++ b/src/dynamics/video_recorder/recorder/recorder.html
@@ -167,6 +167,7 @@
 		ba-topmessage="{{playertopmessage}}"
 		ba-allowtexttrackupload="{{allowtexttrackupload}}"
 		ba-uploadtexttracksvisible="{{uploadtexttracksvisible}}"
+		ba-snapshottype="{{snapshottype}}"
 		ba-tracktags="{{tracktags}}"
 		ba-tracktagsstyled="{{tracktagsstyled}}"
 		ba-trackcuetext="{{trackcuetext}}"

--- a/src/dynamics/video_recorder/recorder/recorder.js
+++ b/src/dynamics/video_recorder/recorder/recorder.js
@@ -1299,6 +1299,7 @@ Scoped.define("module:VideoRecorder.Dynamics.Recorder", [
             "software-waiting": "Waiting for the requirements to be installed / activated. You might need to refresh the page after completion.",
             "access-forbidden": "Access to the media was forbidden. Click to retry.",
             "pick-covershot": "Pick a covershot.",
+            "pick-covershot-frame": "Select a frame to use as covershot.",
             "framerate-warning": "The video frame rate is very low. We recommend closing all other programs and browser tabs or to use a faster computer.",
             "uploading": "Uploading",
             "uploading-failed": "Uploading failed - click here to retry.",

--- a/src/dynamics/video_recorder/recorder/recorder.js
+++ b/src/dynamics/video_recorder/recorder/recorder.js
@@ -195,7 +195,8 @@ Scoped.define("module:VideoRecorder.Dynamics.Recorder", [
                     "videometadata": {},
                     "optionsinitialstate": {},
                     "playerfallbackwidth": 320,
-                    "playerfallbackheight": 240
+                    "playerfallbackheight": 240,
+                    "pickcovershotframe": false
                 },
 
                 computed: {
@@ -312,7 +313,8 @@ Scoped.define("module:VideoRecorder.Dynamics.Recorder", [
                     "showsettingsmenu": "boolean",
                     "showplayersettingsmenu": "boolean",
                     "initialmessages": "array",
-                    "screenrecordmandatory": "boolean"
+                    "screenrecordmandatory": "boolean",
+                    "pickcovershotframe": "boolean"
                 },
 
                 extendables: ["states"],

--- a/src/dynamics/video_recorder/recorder/states.js
+++ b/src/dynamics/video_recorder/recorder/states.js
@@ -323,16 +323,7 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.Chooser", [
                 this.dyn._uploadVideoFile(file);
                 this._setValueToEmpty(file);
                 this.__blocked = false;
-                if (((Info.isMobile && this.dyn.get("recordviafilecapture") && this.dyn.get("snapshotfrommobilecapture")) || this.dyn.get("snapshotfromuploader")) && !this.dyn.get("onlyaudio") && (this.dyn.get("picksnapshots") || this.dyn.get("selectfirstcovershotonskip"))) {
-                    if (!this.dyn.get("picksnapshots") && this.dyn.get("selectfirstcovershotonskip"))
-                        this.dyn.set("snapshotmax", 1);
-                    this.dyn.snapshots = [];
-                    this.next("CreateUploadCovershot");
-                } else if (this.dyn.get("custom-covershots")) {
-                    this.next("CovershotSelection");
-                } else {
-                    this.next("Uploading");
-                }
+                this.next("CovershotSelection");
             }, this).error(function(s) {
                 this._setValueToEmpty(file);
                 this.__blocked = false;
@@ -499,13 +490,7 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.CreateUploadCoversho
                         _video.remove();
                     else
                         _video.style.display = 'none';
-                    if (this.dyn.snapshots.length >= this.dyn.get("gallerysnapshots")) {
-                        this.next("CovershotSelection");
-                    } else {
-                        if (this.dyn.get("selectfirstcovershotonskip") && this.dyn.snapshots.length > 0)
-                            this.dyn._uploadCovershot(this.dyn.snapshots[0]);
-                        this.next("Uploading");
-                    }
+                    this.next("CovershotSelection");
                 }, this);
 
             } catch (exe) {
@@ -911,13 +896,7 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.Recording", [
             Async.eventually(function() {
                 this.dyn._stopRecording().success(function() {
                     this._hasStopped();
-                    var snapshotsCount = this.dyn.snapshots.length;
-                    if ((this.dyn.get("picksnapshots") && (snapshotsCount >= Math.min(this.dyn.get("gallerysnapshots"), snapshotsCount)) && snapshotsCount > 0) || this.dyn.get("custom-covershots"))
-                        this.next("CovershotSelection");
-                    else if (this.dyn.get("videometadata").thumbnails.images.length > 3 && this.dyn.get("createthumbnails"))
-                        this.next("UploadThumbnails");
-                    else
-                        this.next("Uploading");
+                    this.next("CovershotSelection");
                 }, this).error(function(s) {
                     this.next("FatalError", {
                         message: s,
@@ -943,6 +922,57 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.CovershotSelection",
     "module:VideoRecorder.Dynamics.RecorderStates.State"
 ], function(State, scoped) {
     return State.extend({
+        scoped: scoped
+    }, {
+
+        _started: function() {
+            if ((this.dyn.get("picksnapshots") || this.dyn.get("custom-covershots")) && !this.dyn.get("onlyaudio")) {
+                if (this.dyn.snapshots && this.dyn.snapshots.length > 0) {
+                    this.next("CovershotSelectionFromGallery");
+                } else if (this.dyn.get("snapshotfromuploader") || (this.dyn.get("snapshotfrommobilecapture") && this.dyn.get("recordviafilecapture"))) {
+                    this.next("CreateUploadCovershot");
+                } else {
+                    this._nextUploading(true);
+                }
+            } else if (!this.dyn.snapshots && this.dyn.get("snapshotfromuploader") || (this.dyn.get("snapshotfrommobilecapture") && this.dyn.get("recordviafilecapture"))) {
+                if (this.dyn.get("selectfirstcovershotonskip")) {
+                    this.dyn.set("snapshotmax", 1);
+                    this.dyn.snapshots = [];
+                    this.next("CreateUploadCovershot");
+                }
+            } else {
+                this._nextUploading(true);
+            }
+        },
+
+        rerecord: function() {
+            this.dyn._hideBackgroundSnapshot();
+            this.dyn._detachRecorder();
+            this.dyn.trigger("rerecord");
+            this.dyn.set("recordermode", true);
+            this.next("Initial");
+        },
+
+        _nextUploading: function(skippedCovershot) {
+            if (skippedCovershot && this.dyn.get("selectfirstcovershotonskip") && this.dyn.snapshots) {
+                if (this.dyn.snapshots[0]) {
+                    this.dyn._uploadCovershot(this.dyn.snapshots[0]);
+                }
+            }
+            if (this.dyn.get("videometadata").thumbnails.images.length > 3 && this.dyn.get("createthumbnails")) {
+                this.next("UploadThumbnails");
+            } else {
+                this.next("Uploading");
+            }
+        }
+
+    });
+});
+
+Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.CovershotSelectionFromGallery", [
+    "module:VideoRecorder.Dynamics.RecorderStates.CovershotSelection"
+], function(CovershotSelectionState, scoped) {
+    return CovershotSelectionState.extend({
         scoped: scoped
     }, {
 
@@ -973,14 +1003,6 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.CovershotSelection",
             }, this);
         },
 
-        rerecord: function() {
-            this.dyn._hideBackgroundSnapshot();
-            this.dyn._detachRecorder();
-            this.dyn.trigger("rerecord");
-            this.dyn.set("recordermode", true);
-            this.next("Initial");
-        },
-
         uploadCovershot: function(file) {
             // If passed file in HTMLInputElement get file
             if (typeof file.files !== 'undefined')
@@ -988,18 +1010,7 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.CovershotSelection",
                     file = file.files[0];
             this.dyn._uploadCovershotFile(file);
             this._nextUploading(false);
-        },
-
-        _nextUploading: function(skippedCovershot) {
-            if (skippedCovershot && this.dyn.get("selectfirstcovershotonskip") && this.dyn.snapshots)
-                if (this.dyn.snapshots[0])
-                    this.dyn._uploadCovershot(this.dyn.snapshots[0]);
-            if (this.dyn.get("videometadata").thumbnails.images.length > 3 && this.dyn.get("createthumbnails"))
-                this.next("UploadThumbnails");
-            else
-                this.next("Uploading");
         }
-
     });
 });
 

--- a/src/dynamics/video_recorder/recorder/states.js
+++ b/src/dynamics/video_recorder/recorder/states.js
@@ -1031,6 +1031,7 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.CovershotSelectionFr
         _started: function() {
             this._poster = this.dyn.get("playerattrs").poster;
             this._source = this.dyn.get("playerattrs").source;
+            this._skipinitial = this.dyn.get("playerattrs").skipinitial;
 
             var source = this.dyn._videoFile || this.dyn.recorder.localPlaybackSource();
             var blob = this.dyn._videoFile || this.dyn.recorder.localPlaybackSource().src;
@@ -1071,6 +1072,7 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.CovershotSelectionFr
             this.dyn.set("playerattrs.poster", options.poster);
             this.dyn.set("playerattrs.source", options.source);
             this.dyn.set("playertopmessage", this.dyn.string("pick-covershot-frame"));
+            this.dyn.set("playerattrs.skipinitial", true);
             this.dyn.set("player_active", true);
         },
 
@@ -1078,6 +1080,7 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.CovershotSelectionFr
             this.dyn.set("frameselectionmode", false);
             this.dyn.set("playerattrs.poster", this._poster);
             this.dyn.set("playerattrs.source", this._source);
+            this.dyn.set("playerattrs.skipinitial", this._skipinitial);
         },
 
         _end: function() {

--- a/src/dynamics/video_recorder/recorder/states.js
+++ b/src/dynamics/video_recorder/recorder/states.js
@@ -1023,9 +1023,35 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.CovershotSelectionFr
         scoped: scoped
     }, {
 
-        _started: function() {},
+        _poster: undefined,
+        _source: undefined,
 
-        _end: function() {}
+        _started: function() {
+            this._poster = this.dyn.get("playerattrs").poster;
+            this._source = this.dyn.get("playerattrs").source;
+
+            var source = this.dyn._videoFile || this.dyn.recorder.localPlaybackSource();
+
+            this.startFrameSelection({
+                poster: this.dyn.__backgroundSnapshot,
+                source: source
+            });
+        },
+
+        startFrameSelection: function(options) {
+            this.dyn.set("playerattrs.poster", options.poster);
+            this.dyn.set("playerattrs.source", options.source);
+            this.dyn.set("player_active", true);
+        },
+
+        endFrameSelection: function() {
+            this.dyn.set("playerattrs.poster", this._poster);
+            this.dyn.set("playerattrs.source", this._source);
+        },
+
+        _end: function() {
+            this.endFrameSelection();
+        }
     });
 });
 

--- a/src/dynamics/video_recorder/recorder/states.js
+++ b/src/dynamics/video_recorder/recorder/states.js
@@ -1067,12 +1067,14 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.CovershotSelectionFr
         },
 
         startFrameSelection: function(options) {
+            this.dyn.set("frameselectionmode", true);
             this.dyn.set("playerattrs.poster", options.poster);
             this.dyn.set("playerattrs.source", options.source);
             this.dyn.set("player_active", true);
         },
 
         endFrameSelection: function() {
+            this.dyn.set("frameselectionmode", false);
             this.dyn.set("playerattrs.poster", this._poster);
             this.dyn.set("playerattrs.source", this._source);
         },

--- a/src/dynamics/video_recorder/recorder/states.js
+++ b/src/dynamics/video_recorder/recorder/states.js
@@ -18,7 +18,8 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.State", [
                 "controlbar": false,
                 "loader": false,
                 "imagegallery": false,
-                "helperframe": false
+                "helperframe": false,
+                "player": false
             }, Objs.objectify(this.dynamics)), function(value, key) {
                 this.dyn.set(key + "_active", value);
             }, this);
@@ -1074,6 +1075,11 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.CovershotSelectionFr
             this.dyn.set("playertopmessage", this.dyn.string("pick-covershot-frame"));
             this.dyn.set("playerattrs.skipinitial", true);
             this.dyn.set("player_active", true);
+
+            this.listenOn(this.dyn.scopes.player, "image-selected", function(image) {
+                this.dyn._uploadCovershot(image);
+                this._nextUploading(false);
+            }, this);
         },
 
         endFrameSelection: function() {

--- a/src/dynamics/video_recorder/recorder/states.js
+++ b/src/dynamics/video_recorder/recorder/states.js
@@ -1070,6 +1070,7 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.CovershotSelectionFr
             this.dyn.set("frameselectionmode", true);
             this.dyn.set("playerattrs.poster", options.poster);
             this.dyn.set("playerattrs.source", options.source);
+            this.dyn.set("playertopmessage", this.dyn.string("pick-covershot-frame"));
             this.dyn.set("player_active", true);
         },
 

--- a/src/dynamics/video_recorder/recorder/states.js
+++ b/src/dynamics/video_recorder/recorder/states.js
@@ -927,7 +927,9 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.CovershotSelection",
 
         _started: function() {
             if ((this.dyn.get("picksnapshots") || this.dyn.get("custom-covershots")) && !this.dyn.get("onlyaudio")) {
-                if (this.dyn.snapshots && this.dyn.snapshots.length > 0) {
+                if (this.dyn.get("pickcovershotframe") && ((this.dyn.recorder && this.dyn.recorder.supportsLocalPlayback()) || (this.dyn._videoFile && this.dyn._videoFilePlaybackable))) {
+                    this.next("CovershotSelectionFromPlayer");
+                } else if (this.dyn.snapshots && this.dyn.snapshots.length > 0) {
                     this.next("CovershotSelectionFromGallery");
                 } else if (this.dyn.get("snapshotfromuploader") || (this.dyn.get("snapshotfrommobilecapture") && this.dyn.get("recordviafilecapture"))) {
                     this.next("CreateUploadCovershot");
@@ -1011,6 +1013,19 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.CovershotSelectionFr
             this.dyn._uploadCovershotFile(file);
             this._nextUploading(false);
         }
+    });
+});
+
+Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.CovershotSelectionFromPlayer", [
+    "module:VideoRecorder.Dynamics.RecorderStates.CovershotSelection"
+], function(CovershotSelectionState, scoped) {
+    return CovershotSelectionState.extend({
+        scoped: scoped
+    }, {
+
+        _started: function() {},
+
+        _end: function() {}
     });
 });
 

--- a/src/themes/video_player/cube/colors.scss
+++ b/src/themes/video_player/cube/colors.scss
@@ -2,8 +2,7 @@
   @if $color != default {
     .#{$cssplayer}-#{$color}-color {
 
-      .#{$csstheme}-dashboard, .#{$csstheme}-title, .#{$csstheme}-button-inner,
-      .#{$csstheme}-button-inner > i {
+      .#{$csstheme}-dashboard, .#{$csstheme}-title, .#{$csstheme}-button-inner > i {
         color: $value;
       }
 
@@ -22,7 +21,7 @@
       }
 
       .#{$csstheme}-volumebar-position, .#{$csstheme}-stream-label,
-      .#{$csstheme}-progressbar-position,
+      .#{$csstheme}-progressbar-position, .#{$csstheme}-select-button,
       .#{$csstheme}-rerecord-button, .#{$cssplayer}-button-active, .#{$csstheme}-playbutton-duration {
         background-color: $value;
       }

--- a/src/themes/video_player/cube/controlbar.scss
+++ b/src/themes/video_player/cube/controlbar.scss
@@ -189,6 +189,11 @@
     width: 32px;
 }
 
+.#{$csstheme}-select-button {
+  color: $button_color;
+  background-color: $button_color_secondary;
+}
+
 .#{$cssplayer}-size-small {
   .#{$csstheme}-button-container {
     width: $button-width_mobile;

--- a/src/themes/video_player/cube/cube-video_player_controlbar.html
+++ b/src/themes/video_player/cube/cube-video_player_controlbar.html
@@ -163,6 +163,15 @@
                 <i class="{{csscommon}}-icon-cog"></i>
             </div>
         </div>
+
+        <div tabindex="11" class="{{csstheme}}-button-container" ba-if="{{frameselectionmode}}">
+            <div data-selector="select-frame-button"
+                 onmouseout="this.blur()"
+                 ba-click="{{select_frame()}}"
+                 class="{{csstheme}}-button-inner {{csstheme}}-select-button">
+                 {{string('select-frame')}}
+            </div>
+        </div>
     </div>
 
     <div class="{{csstheme}}-progressbar {{disableseeking ? cssplayer + '-disabled' : ''}}">

--- a/src/themes/video_player/elevate/colors.scss
+++ b/src/themes/video_player/elevate/colors.scss
@@ -3,7 +3,7 @@
     .#{$cssplayer}-#{$color}-color {
 
       .#{$csstheme}-dashboard .#{$cssplayer}-button-inactive .#{$csscommon}-icon-subtitle,
-      .#{$csstheme}-button-inner i {
+      .#{$csstheme}-button-inner i, .#{$csstheme}-button-inner.#{$csstheme}-select-button {
         color: $value;
       }
 

--- a/src/themes/video_player/elevate/controlbar.scss
+++ b/src/themes/video_player/elevate/controlbar.scss
@@ -2,6 +2,8 @@
 
 .#{$csstheme} {
 
+    font-family: $text_fontfamily;
+
     .#{$csscommon}-icon-play, .#{$csscommon}-icon-pause {
         color: $button_color;
     }
@@ -169,7 +171,6 @@
     position: relative;
     top: $progressbar_height + 2;
     text-align: center;
-    font-family: $text_fontfamily;
     font-size: $text_fontsize;
     box-sizing: content-box;
     border: none;
@@ -343,3 +344,10 @@
     width: 32px;
 }
 
+.#{$csstheme}-select-button {
+    padding: 0 10px;
+}
+
+.#{$csstheme}-select-button-container {
+    width: auto;
+}

--- a/src/themes/video_player/elevate/elevate-video_player_controlbar.html
+++ b/src/themes/video_player/elevate/elevate-video_player_controlbar.html
@@ -200,6 +200,15 @@
                 </div>
             </div>
 
+            <div tabindex="11" class="{{csstheme}}-select-button-container {{csstheme}}-button-container" ba-if="{{frameselectionmode}}">
+                <div data-selector="select-frame-button"
+                     onmouseout="this.blur()"
+                     ba-click="{{select_frame()}}"
+                     class="{{csstheme}}-select-button {{csstheme}}-button-inner">
+                     {{string('select-frame')}}
+                </div>
+            </div>
+
         </div>
 
     </div>

--- a/src/themes/video_player/minimalist/colors.scss
+++ b/src/themes/video_player/minimalist/colors.scss
@@ -2,7 +2,7 @@
   @if $color != default {
     .#{$cssplayer}-#{$color}-color {
 
-      .#{$csstheme}-title p, .#{$csstheme}-button-inner,
+      .#{$csstheme}-title p,
       .#{$csstheme}-controlbar-top-block .#{$csstheme}-button-container .#{$csstheme}-button-inner {
         color: $value;
       }
@@ -22,7 +22,7 @@
         &.#{$csscommon}-settings-visible .#{$csscommon}-icon-cog {
           color: $value;
         }
-        &.#{$cssplayer}-button-inactive, &.#{$csscommon}-settings-hidden {
+        &.#{$cssplayer}-button-inactive, &.#{$csscommon}-settings-hidden, .#{$csstheme}-select-button {
           background-color: $value;
         }
 

--- a/src/themes/video_player/minimalist/controlbar.scss
+++ b/src/themes/video_player/minimalist/controlbar.scss
@@ -1,6 +1,8 @@
 
 .#{$csstheme} {
 
+    font-family: $font_family;
+    
     .ba-settings-overlay-inner {
         right: $controlbar_side_padding;
     }
@@ -45,62 +47,62 @@
 
 /* Control Bar Header*/
 .#{$csstheme}-controlbar-header {
-  @include background-rgba( 0,0,0, 0.3, #ddd );
-  height: $controlbar_header_height;
-  left: 0;
-  letter-spacing: .05rem;
-  line-height: $topmessage_height / 2;
-  padding: 0;
-  position: absolute;
-  text-align: left;
-  width: 100%;
-  .#{$csstheme}-right-block {
-    line-height: $topmessage_height - 10px;
+    @include background-rgba( 0,0,0, 0.3, #ddd );
+    height: $controlbar_header_height;
+    left: 0;
+    letter-spacing: .05rem;
+    line-height: $topmessage_height / 2;
+    padding: 0;
     position: absolute;
-    right: $controlbar_side_padding;
-    z-index: 100;
-  }
+    text-align: left;
+    width: 100%;
+    .#{$csstheme}-right-block {
+        line-height: $topmessage_height - 10px;
+        position: absolute;
+        right: $controlbar_side_padding;
+        z-index: 100;
+    }
 }
 
 .#{$cssie8} .#{$csstheme}-controlbar-header {
-  display: none;
+    display: none;
 }
 
 .#{$csstheme}-controlbar-header-title-block {
-  position: relative;
-  width: 100%;
-  z-index: 10;
+    position: relative;
+    width: 100%;
+    z-index: 10;
 }
 
 .#{$cssie8} .#{$csstheme}-controlbar-header .#{$csstheme}-right-block {
-  position: relative;
+    position: relative;
 }
 
 .#{$cssie8} .#{$csstheme}-controlbar-header-title-block {
-  left: 50px;
+    left: 50px;
 }
 
 .#{$csstheme}-title {
-  p {
-    color: $text_color;
-    font-family: $font_family;
-    font-size: $controlbar_video_title_font_size;
-    font-weight: 300;
-    letter-spacing: .1em;
-    line-height: $topmessage_height - 10;
-    margin: 0;
-    padding: 0 0 0 $controlbar_side_padding;
-    text-align: left;
-  }
+    p {
+        color: $text_color;
+        font-family: $font_family;
+        font-size: $controlbar_video_title_font_size;
+        font-weight: 300;
+        letter-spacing: .1em;
+        line-height: $topmessage_height - 10;
+        margin: 0;
+        padding: 0 0 0 $controlbar_side_padding;
+        text-align: left;
+    }
 }
 
 .#{$cssnoie8} .#{$csstheme}-controlbar-header .#{$csstheme}-button-inner {
-  text-align: right;
-  @include transform-translate-y(0);
+    text-align: right;
+    @include transform-translate-y(0);
 }
 
 .#{$cssnoie8} .#{$csstheme}-topmessage-container .#{$csstheme}-rightbutton-container {
-  width: 25px; padding-top: 5px;
+    width: 25px; padding-top: 5px;
 }
 
 .#{$csstheme}-controlbar-header .#{$csstheme}-button-container {
@@ -109,8 +111,8 @@
 
 /* Control Bar Footer*/
 .#{$csstheme}-controlbar-footer {
-  position:relative;
-  height: 100%;
+    position:relative;
+    height: 100%;
 }
 
 .#{$csstheme}-controlbar-top-block {
@@ -136,36 +138,36 @@
 }
 
 .#{$cssnoie8} {
-  .#{$css}-overlay {
-    .#{$csstheme}-controlbar-top-block {
-      .#{$csstheme}-button-inner {
-        @include transition1(opacity, 0.3s, ease);
-        opacity: 0;
-      }
+    .#{$css}-overlay {
+        .#{$csstheme}-controlbar-top-block {
+            .#{$csstheme}-button-inner {
+                @include transition1(opacity, 0.3s, ease);
+                opacity: 0;
+            }
+        }
+        &:hover .#{$csstheme}-controlbar-top-block {
+            .#{$csstheme}-button-inner {
+                @include transition1(opacity, 0.2s, ease);
+                opacity: .6;
+            }
+        }
     }
-    &:hover .#{$csstheme}-controlbar-top-block {
-      .#{$csstheme}-button-inner {
-        @include transition1(opacity, 0.2s, ease);
-        opacity: .6;
-      }
-    }
-  }
 }
 
 .#{$cssie8} {
-  .#{$css}-overlay {
-    height: 100%;
-    .#{$csstheme}-controlbar-top-block {
-      .#{$csstheme}-button-inner {
-        @include transparent(0);
-      }
+    .#{$css}-overlay {
+        height: 100%;
+        .#{$csstheme}-controlbar-top-block {
+            .#{$csstheme}-button-inner {
+                @include transparent(0);
+            }
+        }
+        &:hover .#{$csstheme}-controlbar-top-block {
+            .#{$csstheme}-button-inner {
+                @include transparent(.6);
+            }
+        }
     }
-    &:hover .#{$csstheme}-controlbar-top-block {
-      .#{$csstheme}-button-inner {
-        @include transparent(.6);
-      }
-    }
-  }
 }
 
 .#{$csstheme}-button-inner { @include clickable; z-index: 100; position: relative; }
@@ -216,7 +218,7 @@
 }
 
 .#{$csstheme}-progressbar.#{$cssplayer}-disabled {
-  & .#{$csstheme}-progressbar-cache, & .#{$csstheme}-progressbar-inner, & .#{$csstheme}-progressbar-position {cursor: not-allowed}
+    &.#{$csstheme}-progressbar-cache, &.#{$csstheme}-progressbar-inner, &.#{$csstheme}-progressbar-position {cursor: not-allowed}
 }
 
 .#{$csstheme}-progressbar-position {
@@ -268,7 +270,7 @@
         }
     }
     & > div:first-child{
-      //opacity: 1;
+        //opacity: 1;
     }
     & > p {
         float: left;
@@ -295,68 +297,68 @@
 }
 
 .#{$csstheme}-volumebar {
-  float: right;
-  height: $controlbar_header_height;
-  margin-left: 10px;
-  position: relative;
-  width: $volume_width;
-  z-index: 10;
+    float: right;
+    height: $controlbar_header_height;
+    margin-left: 10px;
+    position: relative;
+    width: $volume_width;
+    z-index: 10;
 }
 
 .#{$csstheme}-volumebar-inner {
-  @include relative-center-center;
-  @include border-round-edges($volume_height / 2);
-  @include clickable;
-  background-color: $volumebar_inner_color;
-  height: $volume_height;
+    @include relative-center-center;
+    @include border-round-edges($volume_height / 2);
+    @include clickable;
+    background-color: $volumebar_inner_color;
+    height: $volume_height;
 }
 
 .#{$csstheme}-volumebar-position {
-  @include border-round-edges($volume_height / 2);
-  @include absolute-align-left();
-  background-color: $volumebar_position_bg;
-  height: 100%;
+    @include border-round-edges($volume_height / 2);
+    @include absolute-align-left();
+    background-color: $volumebar_position_bg;
+    height: 100%;
 }
 
 .#{$cssplayer}-size-medium {
-
-  .#{$csstheme}-controlbar-top-block {
-    .#{$csstheme}-button-container {
-      .#{$csstheme}-button-inner {
-        font-size: $controlbar_playbutton_font_size - .5;
-      }
+    
+    .#{$csstheme}-controlbar-top-block {
+        .#{$csstheme}-button-container {
+            .#{$csstheme}-button-inner {
+                font-size: $controlbar_playbutton_font_size - .5;
+            }
+        }
     }
-  }
 }
 
 .#{$cssplayer}-size-small {
-  .#{$csstheme}-volumebar {
-    display: none;
-  }
-
-  .#{$csstheme}-controlbar-header {
-    top: 7px;
-  }
-
-  .#{$csstheme}-controlbar-top-block {
-    .#{$csstheme}-button-container {
-      .#{$csstheme}-button-inner {
-        font-size: $controlbar_playbutton_font_size - .7;
-      }
+    .#{$csstheme}-volumebar {
+        display: none;
     }
-  }
-
-  .#{$csstheme}-controlbar-middle-block {
-    bottom: 40px;
-  }
-
-  .#{$csstheme}-controlbar-bottom-block {
-    bottom: 38px;
-  }
-
-  .#{$csstheme}-time-container{
-    font-size: .7em;
-  }
+    
+    .#{$csstheme}-controlbar-header {
+        top: 7px;
+    }
+    
+    .#{$csstheme}-controlbar-top-block {
+        .#{$csstheme}-button-container {
+            .#{$csstheme}-button-inner {
+                font-size: $controlbar_playbutton_font_size - .7;
+            }
+        }
+    }
+    
+    .#{$csstheme}-controlbar-middle-block {
+        bottom: 40px;
+    }
+    
+    .#{$csstheme}-controlbar-bottom-block {
+        bottom: 38px;
+    }
+    
+    .#{$csstheme}-time-container{
+        font-size: .7em;
+    }
 }
 
 .#{$csstheme}-cast-button-container button {
@@ -399,4 +401,16 @@
         background-color: $cc_label_bg_color;
         opacity: 0.75;
     }
+}
+
+.#{$csstheme}-select-button-container {
+    width: auto;
+}
+
+.#{$csstheme}-select-button-container > .#{$csstheme}-select-button {
+    height: auto;
+    transform: none;
+    padding: 3px;
+    line-height: normal;
+    background-color: $secondary_color;
 }

--- a/src/themes/video_player/minimalist/minimalist-video_player_controlbar.html
+++ b/src/themes/video_player/minimalist/minimalist-video_player_controlbar.html
@@ -166,7 +166,7 @@
                 <button class="{{csstheme}}-gcast-button" is="google-cast-button"></button>
             </div>
 
-            <div tabindex="9" data-selector="button-icon-settings"
+            <div tabindex="10" data-selector="button-icon-settings"
                  ba-hotkey:space^enter="{{toggle_settings_menu()}}" onmouseout="this.blur()"
                  class="{{csstheme}}-right-button-container {{cssplayer}}-settings-{{settingsmenuactive ? 'visible' : 'hidden'}}"
                  ba-if="{{settingsmenubutton}}" ba-click="{{toggle_settings_menu()}}"
@@ -175,6 +175,15 @@
             >
                 <div class="{{csstheme}}-settings-button">
                     <i class="{{csscommon}}-icon-cog"></i>
+                </div>
+            </div>
+
+            <div tabindex="9" class="{{csstheme}}-select-button-container {{csstheme}}-right-button-container" ba-if="{{frameselectionmode}}">
+                <div data-selector="select-frame-button"
+                     onmouseout="this.blur()"
+                     ba-click="{{select_frame()}}"
+                     class="{{csstheme}}-select-button {{csstheme}}-button-inner">
+                     {{string('select-frame')}}
                 </div>
             </div>
 

--- a/src/themes/video_player/minimalist/theme.scss
+++ b/src/themes/video_player/minimalist/theme.scss
@@ -16,6 +16,7 @@ $text_fontfamily: Helvetica Neue, Helvetica, Arial, sans-serif;
 $text_fontsize: 13px;
 $text_color: #eeeeee;
 $text_secondary_color: rgba(250, 254, 255, 0.35);
+$secondary_color: #979797;
 
 // cover
 $cover_playbutton_color: #eeeeee;

--- a/src/themes/video_player/modern/controlbar.scss
+++ b/src/themes/video_player/modern/controlbar.scss
@@ -5,6 +5,7 @@
 	height: $controlbar_height;
     opacity: 0.9;
     overflow: hidden;
+    font-family: $font_family;
 
     .#{$csstheme}-rightbutton-container.#{$cssplayer}-airplay-container {
         height: 28px;
@@ -203,4 +204,12 @@
     .#{$csstheme}-time-value, .#{$csstheme}-time-container {
         width: $time_value_width / 2;
     }
+}
+
+.#{$csstheme}-rightbutton-container.#{$csstheme}-select-button-container {
+    width: auto;
+}
+
+.#{$csstheme}-select-button {
+    padding: 0 10px;
 }

--- a/src/themes/video_player/modern/modern-video_player_controlbar.html
+++ b/src/themes/video_player/modern/modern-video_player_controlbar.html
@@ -58,6 +58,15 @@
 		</div>
 	</div>
 
+	<div tabindex="11" class="{{csstheme}}-select-button-container {{csstheme}}-rightbutton-container" ba-if="{{frameselectionmode}}">
+		<div data-selector="select-frame-button"
+			 onmouseout="this.blur()"
+			 ba-click="{{select_frame()}}"
+			 class="{{csstheme}}-select-button {{csstheme}}-button-inner">
+			 {{string('select-frame')}}
+		</div>
+	</div>
+
 	<div tabindex="10" data-selector="button-icon-settings"
 		 ba-hotkey:space^enter="{{toggle_settings_menu()}}" onmouseout="this.blur()"
 		 class="{{csstheme}}-rightbutton-container {{cssplayer}}-button-{{settingsmenuactive ? 'active' : 'inactive'}}"

--- a/src/themes/video_player/space/colors.scss
+++ b/src/themes/video_player/space/colors.scss
@@ -3,12 +3,11 @@
     .#{$cssplayer}-#{$color}-color {
 
       .#{$csstheme}-title > p,
-      &.#{$cssnoie8} .#{$csstheme}-button-inner,
-      &.#{$cssie8} .#{$csstheme}-button-inner {
+      .#{$csstheme}-button-inner {
         color: $value;
       }
 
-      &.#{$cssnoie8} .#{$csstheme}-stream-label-container,
+      &.#{$cssnoie8} .#{$csstheme}-stream-label-container, .#{$csstheme}-select-button,
       &.#{$cssie8} .#{$csstheme}-stream-label-container, .#{$cssplayer}-button-active {
         color: $button_color;
         background-color: $value;

--- a/src/themes/video_player/space/controlbar.scss
+++ b/src/themes/video_player/space/controlbar.scss
@@ -1,5 +1,6 @@
 
 .#{$csstheme}-dashboard {
+    font-family: $font_family;
     .#{$cssplayer}-airplay-container {
         box-sizing: content-box;
         padding: 12px 0 0 6px;
@@ -54,7 +55,6 @@
     & > p {
         margin: 0;
         font-size: $controlbar_title_font_size;
-        font-family: $font_family;
     }
 }
 
@@ -92,13 +92,11 @@
     padding-right: 10px;
 }
 
-.#{$cssnoie8} .#{$csstheme}-button-inner {
+.#{$csstheme}-button-inner {
+    @include clickable;
     color: $button_color;
     font-size: $button_fontsize;
-}
-
-.#{$csstheme}-button-inner {
-  @include clickable;
+    border-radius: 3px;
 }
 
 .#{$cssnoie8} .#{$csstheme}-controlbar-footer .#{$csstheme}-button-inner {
@@ -106,8 +104,6 @@
 }
 
 .#{$cssie8} .#{$csstheme}-button-inner {
-    color: $button_color;
-    font-size: $button_fontsize;
     height: auto;
     margin-top: $ie8_margintop + 8;
     margin-left: 3px;
@@ -283,4 +279,10 @@
 
 .ba-settings-overlay-inner {
     bottom: 40px;
+}
+
+.#{$csstheme}-select-button {
+    background-color: white;
+    color: $main_color;
+    padding: 5px;
 }

--- a/src/themes/video_player/space/space-video_player_controlbar.html
+++ b/src/themes/video_player/space/space-video_player_controlbar.html
@@ -84,7 +84,7 @@
             </div>
         </div>
 
-        <div tabindex="10" data-selector="button-icon-settings"
+        <div tabindex="11" data-selector="button-icon-settings"
              ba-hotkey:space^enter="{{toggle_settings_menu()}}" onmouseout="this.blur()"
              class="{{csstheme}}-rightbutton-container {{csstheme}}-settings-button-container {{cssplayer}}-button-{{settingsmenuactive ? 'active' : 'inactive'}}"
              ba-if="{{settingsmenubutton}}" ba-click="{{toggle_settings_menu()}}"
@@ -96,7 +96,7 @@
             </div>
         </div>
 
-        <div tabindex="9" data-selector="cc-button-container"
+        <div tabindex="10" data-selector="cc-button-container"
              ba-hotkey:space^enter="{{toggle_tracks()}}" onmouseout="this.blur()"
              ba-if="{{(tracktags.length > 0 && showsubtitlebutton) || allowtexttrackupload}}"
              class="{{csstheme}}-rightbutton-container {{csstheme}}-cc-button-container {{cssplayer}}-button-{{tracktextvisible ? 'active' : 'inactive'}}"
@@ -110,7 +110,7 @@
             </div>
         </div>
 
-        <div tabindex="8" data-selector="button-icon-resize-full"
+        <div tabindex="9" data-selector="button-icon-resize-full"
              ba-hotkey:space^enter="{{toggle_fullscreen()}}" onmouseout="this.blur()"
              onkeydown="{{tab_index_move(domEvent)}}"
              class="{{csstheme}}-rightbutton-container"
@@ -118,6 +118,15 @@
         >
             <div class="{{csstheme}}-button-inner {{csstheme}}-full-screen-btn-inner">
                 <i class="{{csscommon}}-icon-{{fullscreened ? 'resize-minimize' : 'resize-full'}}"></i>
+            </div>
+        </div>
+
+        <div tabindex="8" class="{{csstheme}}-rightbutton-container" ba-if="{{frameselectionmode}}">
+            <div data-selector="select-frame-button"
+                 onmouseout="this.blur()"
+                 ba-click="{{select_frame()}}"
+                 class="{{csstheme}}-select-button {{csstheme}}-button-inner">
+                 {{string('select-frame')}}
             </div>
         </div>
 

--- a/src/themes/video_player/theatre/colors.scss
+++ b/src/themes/video_player/theatre/colors.scss
@@ -2,7 +2,7 @@
   @if $color != default {
     .#{$cssplayer}-#{$color}-color {
 
-      .#{$csstheme}-title, .#{$csstheme}-button-inner i,
+      .#{$csstheme}-title, .#{$csstheme}-button-inner i, .#{$csstheme}-button-inner.#{$csstheme}-select-button,
       &.#{$csstheme} .#{$cssplayer}-button-inactive i, &.#{$csstheme} .#{$csscommon}-settings-hidden i {
         color: $value;
       }

--- a/src/themes/video_player/theatre/controlbar.scss
+++ b/src/themes/video_player/theatre/controlbar.scss
@@ -2,6 +2,8 @@
 
 .#{$csstheme} {
 
+    font-family: $font_family;
+
     .#{$csscommon}-icon-play, .#{$csscommon}-icon-pause {
         color: $button_color;
     }
@@ -143,7 +145,7 @@
 }
 
 .#{$cssnoie8} .#{$csstheme}-button-inner {
-    color: $button_color;
+    color: $button_color_secondary;
     font-size: $button_fontsize;
 }
 
@@ -274,7 +276,6 @@
 }
 
 .#{$csstheme}-button-text {
-    font-family: $font_family;
     font-weight: normal;
     font-size: 10px;
 }

--- a/src/themes/video_player/theatre/theatre-video_player_controlbar.html
+++ b/src/themes/video_player/theatre/theatre-video_player_controlbar.html
@@ -93,7 +93,7 @@
 
     <div class="{{csstheme}}-right-block">
 
-        <div tabindex="9" data-selector="button-icon-settings"
+        <div tabindex="10" data-selector="button-icon-settings"
              ba-hotkey:space^enter="{{toggle_settings_menu()}}" onmouseout="this.blur()"
              class="{{csstheme}}-rightbutton-container {{csstheme}}-settings-button-container {{cssplayer}}-button-{{settingsmenuactive ? 'active' : 'inactive'}}"
              ba-if="{{settingsmenubutton}}" ba-click="{{toggle_settings_menu()}}"
@@ -105,7 +105,7 @@
             </div>
         </div>
 
-        <div tabindex="8" data-selector="cc-button-container"
+        <div tabindex="9" data-selector="cc-button-container"
              ba-hotkey:space^enter="{{toggle_tracks()}}" onmouseout="this.blur()"
              ba-if="{{(tracktags.length > 0 && showsubtitlebutton) || allowtexttrackupload}}"
              class="{{csstheme}}-rightbutton-container {{csstheme}}-cc-button-container {{cssplayer}}-button-{{tracktextvisible ? 'active' : 'inactive'}}"
@@ -119,7 +119,7 @@
             </div>
         </div>
 
-        <div tabindex="7" data-selector="button-icon-resize-full"
+        <div tabindex="8" data-selector="button-icon-resize-full"
              ba-hotkey:space^enter="{{toggle_fullscreen()}}" onmouseout="this.blur()"
              onkeydown="{{tab_index_move(domEvent)}}"
              class="{{csstheme}}-button-container {{csstheme}}-fullscreen-icon-container"
@@ -127,6 +127,15 @@
         >
             <div class="{{csstheme}}-button-inner {{csstheme}}-full-screen-btn-inner">
                 <i class="{{csscommon}}-icon-resize-{{fullscreened ? 'small' : 'full'}}"></i>
+            </div>
+        </div>
+
+        <div tabindex="7" class="{{csstheme}}-button-container" ba-if="{{frameselectionmode}}">
+            <div data-selector="select-frame-button"
+                 onmouseout="this.blur()"
+                 ba-click="{{select_frame()}}"
+                 class="{{csstheme}}-select-button {{csstheme}}-button-inner">
+                 {{string('select-frame')}}
             </div>
         </div>
 


### PR DESCRIPTION
This PR introduces the following changes:
- Add `pickcovershotframe` parameter to video recorder. It allows the user to select any frame as covershot.
- Covershot selection was refactored to keep everything encapsulated on the same state.
- A new state `CovershotSelectionFromPlayer` was created to handle frame selection.