### PR TITLE
Fix: audio visualization bugs

### DIFF
--- a/src/dynamics/_common/audio_visualization.js
+++ b/src/dynamics/_common/audio_visualization.js
@@ -64,8 +64,6 @@ Scoped.define("module:AudioVisualization", [
                             this.analyser.connect(this.audioContext.destination);
                         }
 
-                        this.audioBufferSourceNode = this.audioContext.createBufferSource();
-                        this.audioBufferSourceNode.connect(this.analyser);
                         this.bufferLength = this.analyser.frequencyBinCount;
                         // this.dataArray = new Uint8Array(this.analyser.fftSize);
                         this.dataArray = new Uint8Array(this.analyser.frequencyBinCount);
@@ -108,7 +106,6 @@ Scoped.define("module:AudioVisualization", [
                 this.frameID = requestAnimationFrame(function() {
                     _self.renderFrame();
                 });
-                this.dataArray = new Uint8Array(this.analyser.frequencyBinCount);
                 this.analyser.getByteFrequencyData(this.dataArray);
                 // this.dataArray = new Float32Array( this.analyser.fftSize);
                 // this.analyser.getFloatTimeDomainData(this.dataArray);

--- a/src/dynamics/_common/audio_visualization.js
+++ b/src/dynamics/_common/audio_visualization.js
@@ -64,7 +64,6 @@ Scoped.define("module:AudioVisualization", [
                             this.analyser.connect(this.audioContext.destination);
                         }
 
-                        this.analyser.connect(this.audioContext.destination);
                         this.audioBufferSourceNode = this.audioContext.createBufferSource();
                         this.audioBufferSourceNode.connect(this.analyser);
                         this.bufferLength = this.analyser.frequencyBinCount;

--- a/src/dynamics/_common/audio_visualization.js
+++ b/src/dynamics/_common/audio_visualization.js
@@ -56,7 +56,6 @@ Scoped.define("module:AudioVisualization", [
                         }
 
                         if (this.stream instanceof HTMLElement) {
-                            // this.stream.crossOrigin = "anonymous";
                             _source = this.audioContext.createMediaElementSource(this.stream);
                             this.analyser = this._analyser || this.audioContext.createAnalyser();
                             _source.connect(this.analyser);

--- a/src/dynamics/_common/audio_visualization.js
+++ b/src/dynamics/_common/audio_visualization.js
@@ -1,4 +1,4 @@
-Scoped.define("module:AudioVisualisation", [
+Scoped.define("module:AudioVisualization", [
     "base:Class",
     "browser:Dom",
     "browser:Info"
@@ -23,11 +23,11 @@ Scoped.define("module:AudioVisualisation", [
                     var AudioContext = window.AudioContext || window.webkitAudioContext;
                     this.audioContext = new AudioContext();
                 }
-                this.createVisualisationCanvas(options.height, options.element);
+                this.createVisualizationCanvas(options.height, options.element);
                 this.frameID = null;
             },
 
-            createVisualisationCanvas: function(height, element) {
+            createVisualizationCanvas: function(height, element) {
                 var _height, _containerElement;
                 _height = height || 120;
                 _containerElement = (element.firstElementChild || element.firstChild);

--- a/src/dynamics/audio_player/player/player.html
+++ b/src/dynamics/audio_player/player/player.html
@@ -5,7 +5,7 @@
 	ba-styles="{{widthHeightStyles}}"
 >
 	<canvas data-selector="audio-canvas" class="{{csstheme}}-audio-canvas"></canvas>
-    <audio tabindex="-1" class="{{css}}-audio" data-audio="audio"></audio>
+    <audio crossorigin="anonymous" tabindex="-1" class="{{css}}-audio" data-audio="audio"></audio>
     <div class="{{css}}-overlay">
 		<div tabindex="-1" class="{{css}}-player-toggle-overlay" data-selector="player-toggle-overlay"
 			 ba-hotkey:right="{{seek(position + skipseconds)}}" ba-hotkey:left="{{seek(position - skipseconds)}}"

--- a/src/dynamics/audio_player/player/player.js
+++ b/src/dynamics/audio_player/player/player.js
@@ -1,7 +1,7 @@
 Scoped.define("module:AudioPlayer.Dynamics.Player", [
     "dynamics:Dynamic",
     "module:Assets",
-    "module:AudioVisualisation",
+    "module:AudioVisualization",
     "browser:Info",
     "browser:Dom",
     "media:AudioPlayer.AudioPlayerWrapper",
@@ -27,7 +27,7 @@ Scoped.define("module:AudioPlayer.Dynamics.Player", [
     "dynamics:Partials.StylesPartial",
     "dynamics:Partials.TemplatePartial",
     "dynamics:Partials.HotkeyPartial"
-], function(Class, Assets, AudioVisualisation, Info, Dom, AudioPlayerWrapper, Types, Objs, Strings, Time, Timers, Host, ClassRegistry, Async, InitialState, PlayerStates, DomEvents, scoped) {
+], function(Class, Assets, AudioVisualization, Info, Dom, AudioPlayerWrapper, Types, Objs, Strings, Time, Timers, Host, ClassRegistry, Async, InitialState, PlayerStates, DomEvents, scoped) {
     return Class.extend({
             scoped: scoped
         }, function(inherited) {
@@ -160,9 +160,9 @@ Scoped.define("module:AudioPlayer.Dynamics.Player", [
                     "change:visualeffectsupported": function(value) {
                         if (!value) {
                             // If after checking we found that AudioAnalyzer not supported we should remove canvas
-                            if (this.audioVisualisation) {
-                                this.audioVisualisation.destroy();
-                                this.audioVisualisation.canvas.remove();
+                            if (this.audioVisualization) {
+                                this.audioVisualization.destroy();
+                                this.audioVisualization.canvas.remove();
                             }
                         }
                     }
@@ -297,8 +297,8 @@ Scoped.define("module:AudioPlayer.Dynamics.Player", [
 
                         this.player = instance;
                         this.__audio = audio;
-                        // Draw audio visualisation effect
-                        if (this.get("visualeffectvisible") && AudioVisualisation.supported() && !this.audioVisualisation) {
+                        // Draw audio visualization effect
+                        if (this.get("visualeffectvisible") && AudioVisualization.supported() && !this.audioVisualization) {
                             if (this.get("height") && this.get("height") > this.get("visualeffectminheight")) {
                                 this.set('visualeffectheight', this.get("height"));
                             } else if (this.get("visualeffectheight") < this.get("visualeffectminheight")) {
@@ -307,13 +307,13 @@ Scoped.define("module:AudioPlayer.Dynamics.Player", [
 
                             // Will fix Safari and other browsers auto sound off behaviour
                             Dom.userInteraction(function() {
-                                this.audioVisualisation = new AudioVisualisation(audio, {
+                                this.audioVisualization = new AudioVisualization(audio, {
                                     height: this.get('visualeffectheight'),
                                     element: this.activeElement(),
                                     theme: this.get("visualeffecttheme")
                                 });
                                 try {
-                                    this.audioVisualisation.initializeVisualEffect();
+                                    this.audioVisualization.initializeVisualEffect();
                                     this.set("visualeffectsupported", true);
                                 } catch (e) {
                                     this.set("visualeffectsupported", false);
@@ -496,7 +496,7 @@ Scoped.define("module:AudioPlayer.Dynamics.Player", [
                         this.host.state().play();
                         // Draw visual effect
                         if (this.get('visualeffectsupported'))
-                            this.audioVisualisation.renderFrame();
+                            this.audioVisualization.renderFrame();
                     },
 
                     rerecord: function() {
@@ -520,9 +520,9 @@ Scoped.define("module:AudioPlayer.Dynamics.Player", [
                             this.player.pause();
                         }
 
-                        if (this.get("visualeffectsupported") && this.audioVisualisation) {
-                            if (this.audioVisualisation.frameID)
-                                this.audioVisualisation.cancelFrame(this.audioVisualisation.frameID);
+                        if (this.get("visualeffectsupported") && this.audioVisualization) {
+                            if (this.audioVisualization.frameID)
+                                this.audioVisualization.cancelFrame(this.audioVisualization.frameID);
                             else
                                 this.set("visualeffectsupported", false);
                         }

--- a/src/dynamics/audio_recorder/recorder/recorder.html
+++ b/src/dynamics/audio_recorder/recorder/recorder.html
@@ -6,7 +6,7 @@
      ba-styles="{{widthHeightStyles}}"
 >
 
-	<canvas data-selector="visualisation-canvas" class="{{css}}-visualisation-canvas"></canvas>
+	<canvas data-selector="visualization-canvas" class="{{css}}-visualization-canvas"></canvas>
     <audio tabindex="-1" data-selector="recorder-status" class="{{css}}-audio {{css}}-{{hasrecorder ? 'hasrecorder' : 'norecorder'}}" data-audio="audio" playsinline></audio>
     <div data-selector="audio-recorder-overlay" class='{{cssrecorder}}-overlay' ba-show="{{!hideoverlay}}" data-overlay="overlay">
 		<ba-{{dynloader}}

--- a/src/dynamics/audio_recorder/recorder/recorder.js
+++ b/src/dynamics/audio_recorder/recorder/recorder.js
@@ -166,7 +166,8 @@ Scoped.define("module:AudioRecorder.Dynamics.Recorder", [
                     "allowedextensions": "array",
                     "allowcancel": "boolean",
                     "display-timer": "boolean",
-                    "audio-test-mandatory": "boolean"
+                    "audio-test-mandatory": "boolean",
+                    "visualeffectvisible": "boolean"
                 },
 
                 extendables: ["states"],

--- a/src/dynamics/audio_recorder/recorder/recorder.js
+++ b/src/dynamics/audio_recorder/recorder/recorder.js
@@ -1,7 +1,7 @@
 Scoped.define("module:AudioRecorder.Dynamics.Recorder", [
     "dynamics:Dynamic",
     "module:Assets",
-    "module:AudioVisualisation",
+    "module:AudioVisualization",
     "browser:Info",
     "browser:Dom",
     "browser:Upload.MultiUploader",
@@ -33,7 +33,7 @@ Scoped.define("module:AudioRecorder.Dynamics.Recorder", [
     "dynamics:Partials.StylesPartial",
     "dynamics:Partials.TemplatePartial",
     "dynamics:Partials.HotkeyPartial"
-], function(Class, Assets, AudioVisualisation, Info, Dom, MultiUploader, FileUploader, AudioRecorderWrapper, WebRTCSupport, Types, Objs, Strings, Time, Timers, Host, ClassRegistry, Collection, Promise, InitialState, RecorderStates, scoped) {
+], function(Class, Assets, AudioVisualization, Info, Dom, MultiUploader, FileUploader, AudioRecorderWrapper, WebRTCSupport, Types, Objs, Strings, Time, Timers, Host, ClassRegistry, Collection, Promise, InitialState, RecorderStates, scoped) {
     return Class.extend({
             scoped: scoped
         }, function(inherited) {
@@ -190,13 +190,13 @@ Scoped.define("module:AudioRecorder.Dynamics.Recorder", [
                     "change:visualeffectsupported": function(value) {
                         if (!value) {
                             // If after checking we found that AudioAnalyzer not supported we should remove canvas
-                            if (this.audioVisualisation) {
-                                if (this.audioVisualisation.canvas)
-                                    this.audioVisualisation.canvas.remove();
-                                this.audioVisualisation.destroy();
+                            if (this.audioVisualization) {
+                                if (this.audioVisualization.canvas)
+                                    this.audioVisualization.canvas.remove();
+                                this.audioVisualization.destroy();
                             }
-                        } else if (this.audioVisualisation) {
-                            this.audioVisualisation.renderFrame();
+                        } else if (this.audioVisualization) {
+                            this.audioVisualization.renderFrame();
                         }
                     }
                 },
@@ -302,9 +302,9 @@ Scoped.define("module:AudioRecorder.Dynamics.Recorder", [
                     this.recorder = AudioRecorderWrapper.create(Objs.extend({
                         element: audio
                     }, this._audioRecorderWrapperOptions()));
-                    // Draw visualisation effect for the audio player
-                    // if (this.get("visualeffectvisible") && AudioVisualisation.supported()) {
-                    //     this.audioVisualisation = new AudioVisualisation(audio, {
+                    // Draw visualization effect for the audio player
+                    // if (this.get("visualeffectvisible") && AudioVisualization.supported()) {
+                    //     this.audioVisualization = new AudioVisualization(audio, {
                     //         recorder: this.recorder,
                     //         globalAudioContext: WebRTCSupport.globals().audioContext,
                     //         height: this.recorder._recorder._options.recordResolution.height || 120,
@@ -340,14 +340,14 @@ Scoped.define("module:AudioRecorder.Dynamics.Recorder", [
                             this.recorder.setVolumeGain(this.get("microphone-volume"));
                             this.set("hideoverlay", false);
                             this.off("require_display", null, this);
-                            // Draw visualisation effect for the audio player
-                            if (this.get("visualeffectvisible") && AudioVisualisation.supported()) {
+                            // Draw visualization effect for the audio player
+                            if (this.get("visualeffectvisible") && AudioVisualization.supported()) {
                                 if (this.get("height") && this.get("height") > this.get("visualeffectminheight")) {
                                     this.set('visualeffectheight', this.get("height"));
                                 } else if (this.get("visualeffectheight") < this.get("visualeffectminheight")) {
                                     this.set('visualeffectheight', this.get("visualeffectminheight"));
                                 }
-                                this.audioVisualisation = new AudioVisualisation(this.recorder._recorder.stream(), {
+                                this.audioVisualization = new AudioVisualization(this.recorder._recorder.stream(), {
                                     element: this.activeElement(),
                                     recorder: this.recorder,
                                     height: this.get("visualeffectheight"),
@@ -361,7 +361,7 @@ Scoped.define("module:AudioRecorder.Dynamics.Recorder", [
                                     fire: function() {
                                         if (this.recorder._analyser) {
                                             try {
-                                                this.audioVisualisation.initializeVisualEffect();
+                                                this.audioVisualization.initializeVisualEffect();
                                                 this.set("visualeffectsupported", true);
                                             } catch (ex) {
                                                 this.set("visualeffectsupported", false);
@@ -434,9 +434,9 @@ Scoped.define("module:AudioRecorder.Dynamics.Recorder", [
                 _stopRecording: function() {
                     if (!this.__recording)
                         return Promise.error(true);
-                    // Destroy audio visualisation effect for the recorder
-                    if (this.audioVisualisation)
-                        this.audioVisualisation.cancelFrame(this.audioVisualisation.frameID);
+                    // Destroy audio visualization effect for the recorder
+                    if (this.audioVisualization)
+                        this.audioVisualization.cancelFrame(this.audioVisualization.frameID);
                     return this.recorder.stopRecord({
                         audio: this.get("uploadoptions").audio,
                         webrtcStreaming: this.get("uploadoptions").webrtcStreaming
@@ -490,9 +490,9 @@ Scoped.define("module:AudioRecorder.Dynamics.Recorder", [
                             });
                             this.recorder.testSoundLevel(true);
                             this.set("selectedmicrophone", microphone_id);
-                            if (this.audioVisualisation) {
+                            if (this.audioVisualization) {
                                 this.recorder._recorder.on("bound", function() {
-                                    this.audioVisualisation.updateSourceStream();
+                                    this.audioVisualization.updateSourceStream();
                                 }, this);
                             }
                         }


### PR DESCRIPTION
This PR fixes the following issues:

- Audio muted on player when using `visualeffectvisible` due to cross-origin issues
- Microphone echo sound when using `visualeffectvisible` after audio recording starts
- `visualeffectvisible` was being treated as string, so `ba-visualeffectvisible=false` was interpreted as "false", which is truthy and made the effect show up
- Typo on word visualization