### PR TITLE
Feature: manual trimming

### DIFF
--- a/src/dynamics/video_recorder/recorder/recorder.js
+++ b/src/dynamics/video_recorder/recorder/recorder.js
@@ -830,7 +830,7 @@ Scoped.define("module:VideoRecorder.Dynamics.Recorder", [
                 object_functions: [
                     "record", "rerecord", "record_screen", "stop", "play", "pause", "reset", "cancel",
                     "pause_recorder", "resume", "upload_video", "upload_covershot", "select_camera",
-                    "select_microphone", "add_new_stream"
+                    "select_microphone", "add_new_stream", "trim"
                 ],
 
                 functions: {
@@ -1015,6 +1015,11 @@ Scoped.define("module:VideoRecorder.Dynamics.Recorder", [
 
                     toggle_facemode: function() {
                         this._toggleFaceMode();
+                    },
+
+                    trim: function(start, end) {
+                        if (this.host.state().state_name() !== "Trimming") return;
+                        this.trigger("video-trimmed", start, end);
                     },
 
                     manual_submit: function() {

--- a/src/dynamics/video_recorder/recorder/recorder.js
+++ b/src/dynamics/video_recorder/recorder/recorder.js
@@ -1019,7 +1019,7 @@ Scoped.define("module:VideoRecorder.Dynamics.Recorder", [
 
                     trim: function(start, end) {
                         if (this.host.state().state_name() !== "Trimming") return;
-                        this.trigger("video-trimmed", start, end);
+                        this.trigger("manual-trim", start, end);
                     },
 
                     manual_submit: function() {

--- a/src/dynamics/video_recorder/recorder/recorder.js
+++ b/src/dynamics/video_recorder/recorder/recorder.js
@@ -1379,6 +1379,7 @@ Scoped.define("module:VideoRecorder.Dynamics.Recorder", [
             "browser-permission-denied": "Permission denied by browser, please grant access and reload page",
             "screen-recorder-is-not-supported": "Screen recorder is not supported on this device",
             "trim-prompt": "Do you want to trim your video?",
-            "trim-video": "Move the start and end markers to trim your video"
+            "trim-video": "Move the start and end markers to trim your video",
+            "wait-for-trim": "Waiting for trim command..."
         });
 });

--- a/src/dynamics/video_recorder/recorder/recorder.js
+++ b/src/dynamics/video_recorder/recorder/recorder.js
@@ -198,7 +198,8 @@ Scoped.define("module:VideoRecorder.Dynamics.Recorder", [
                     "playerfallbackwidth": 320,
                     "playerfallbackheight": 240,
                     "pickcovershotframe": false,
-                    "allowtrim": false
+                    "allowtrim": false,
+                    "trimoverlay": true
                 },
 
                 computed: {
@@ -317,7 +318,8 @@ Scoped.define("module:VideoRecorder.Dynamics.Recorder", [
                     "initialmessages": "array",
                     "screenrecordmandatory": "boolean",
                     "pickcovershotframe": "boolean",
-                    "allowtrim": "boolean"
+                    "allowtrim": "boolean",
+                    "trimoverlay": "boolean"
                 },
 
                 extendables: ["states"],

--- a/src/dynamics/video_recorder/recorder/states.js
+++ b/src/dynamics/video_recorder/recorder/states.js
@@ -953,10 +953,11 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.Trimming", [
                     this.listenOnce(this.dyn, "manual-trim", function(start, end) {
                         if (Types.isNumber(start) && start > 0) this.dyn.set("starttime", start);
                         if (Types.isNumber(end) && end <= this.get("duration")) this.dyn.set("endtime", end);
-                        this.trigger("video-trimmed", this.dyn.get("starttime"), this.dyn.get("endtime"));
+                        this.dyn.trigger("video-trimmed", this.dyn.get("starttime"), this.dyn.get("endtime"));
                         this.next("Uploading");
                     });
                 }
+                this.dyn.trigger("ready-to-trim");
             }
         },
 
@@ -979,7 +980,7 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.Trimming", [
             this.listenOnce(this.dyn.scopes.player, "video-trimmed skip", function(start, end) {
                 if (start) this.dyn.set("starttime", start);
                 if (end) this.dyn.set("endtime", end);
-                this.trigger("video-trimmed", this.dyn.get("starttime"), this.dyn.get("endtime"));
+                this.dyn.trigger("video-trimmed", this.dyn.get("starttime"), this.dyn.get("endtime"));
                 this.hideTrimmingOverlay();
                 this.next("Uploading");
             }, this);

--- a/src/dynamics/video_recorder/recorder/states.js
+++ b/src/dynamics/video_recorder/recorder/states.js
@@ -948,6 +948,8 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.Trimming", [
                             this.showTrimmingOverlay(this.dyn.__backgroundSnapshot);
                         }, this);
                 } else {
+                    this.dyn.set("message_active", true);
+                    this.dyn.set("message", this.dyn.string("wait-for-trim"));
                     this.listenOnce(this.dyn, "video-trimmed", function(start, end) {
                         if (Types.isNumber(start) && start > 0) this.dyn.set("starttime", start);
                         if (Types.isNumber(end) && end <= this.get("duration")) this.dyn.set("endtime", end);

--- a/src/dynamics/video_recorder/recorder/states.js
+++ b/src/dynamics/video_recorder/recorder/states.js
@@ -938,13 +938,15 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.Trimming", [
             if (!this.dyn.get("allowtrim") || this.dyn.get("duration") < this.dyn.get("timeminlimit")) {
                 this.next("Uploading");
             } else {
-                this.dyn._getFirstFrameSnapshot()
-                    .success(function(snapshot) {
-                        this.showTrimmingOverlay(snapshot);
-                    }, this)
-                    .error(function() {
-                        this.showTrimmingOverlay(this.dyn.__backgroundSnapshot);
-                    }, this);
+                if (this.dyn.get("trimoverlay")) {
+                    this.dyn._getFirstFrameSnapshot()
+                        .success(function(snapshot) {
+                            this.showTrimmingOverlay(snapshot);
+                        }, this)
+                        .error(function() {
+                            this.showTrimmingOverlay(this.dyn.__backgroundSnapshot);
+                        }, this);
+                }
             }
         },
 

--- a/src/dynamics/video_recorder/recorder/states.js
+++ b/src/dynamics/video_recorder/recorder/states.js
@@ -950,9 +950,10 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.Trimming", [
                 } else {
                     this.dyn.set("message_active", true);
                     this.dyn.set("message", this.dyn.string("wait-for-trim"));
-                    this.listenOnce(this.dyn, "video-trimmed", function(start, end) {
+                    this.listenOnce(this.dyn, "manual-trim", function(start, end) {
                         if (Types.isNumber(start) && start > 0) this.dyn.set("starttime", start);
                         if (Types.isNumber(end) && end <= this.get("duration")) this.dyn.set("endtime", end);
+                        this.trigger("video-trimmed", this.dyn.get("starttime"), this.dyn.get("endtime"));
                         this.next("Uploading");
                     });
                 }
@@ -978,6 +979,7 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.Trimming", [
             this.listenOnce(this.dyn.scopes.player, "video-trimmed skip", function(start, end) {
                 if (start) this.dyn.set("starttime", start);
                 if (end) this.dyn.set("endtime", end);
+                this.trigger("video-trimmed", this.dyn.get("starttime"), this.dyn.get("endtime"));
                 this.hideTrimmingOverlay();
                 this.next("Uploading");
             }, this);

--- a/src/dynamics/video_recorder/recorder/states.js
+++ b/src/dynamics/video_recorder/recorder/states.js
@@ -940,15 +940,15 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.Trimming", [
             } else {
                 this.dyn._getFirstFrameSnapshot()
                     .success(function(snapshot) {
-                        this.startTrimming(snapshot);
+                        this.showTrimmingOverlay(snapshot);
                     }, this)
                     .error(function() {
-                        this.startTrimming(this.dyn.__backgroundSnapshot);
+                        this.showTrimmingOverlay(this.dyn.__backgroundSnapshot);
                     }, this);
             }
         },
 
-        startTrimming: function(poster) {
+        showTrimmingOverlay: function(poster) {
             this._playerAttrs = this.dyn.get("playerattrs");
 
             this.dyn.set("playerattrs", {
@@ -967,12 +967,12 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.Trimming", [
             this.listenOnce(this.dyn.scopes.player, "video-trimmed skip", function(start, end) {
                 if (start) this.dyn.set("starttime", start);
                 if (end) this.dyn.set("endtime", end);
-                this.endTrimming();
+                this.hideTrimmingOverlay();
                 this.next("Uploading");
             }, this);
         },
 
-        endTrimming: function() {
+        hideTrimmingOverlay: function() {
             this.dyn.set("trimmingmode", false);
             this.dyn.set("playerattrs", this._playerAttrs);
         }

--- a/src/dynamics/video_recorder/recorder/states.js
+++ b/src/dynamics/video_recorder/recorder/states.js
@@ -928,8 +928,9 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.Recording", [
 });
 
 Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.Trimming", [
-    "module:VideoRecorder.Dynamics.RecorderStates.State"
-], function(State, scoped) {
+    "module:VideoRecorder.Dynamics.RecorderStates.State",
+    "base:Types"
+], function(State, Types, scoped) {
     return State.extend({
         scoped: scoped
     }, {
@@ -946,6 +947,12 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.Trimming", [
                         .error(function() {
                             this.showTrimmingOverlay(this.dyn.__backgroundSnapshot);
                         }, this);
+                } else {
+                    this.listenOnce(this.dyn, "video-trimmed", function(start, end) {
+                        if (Types.isNumber(start) && start > 0) this.dyn.set("starttime", start);
+                        if (Types.isNumber(end) && end <= this.get("duration")) this.dyn.set("endtime", end);
+                        this.next("Uploading");
+                    });
                 }
             }
         },

--- a/src/dynamics/video_recorder/recorder/states.js
+++ b/src/dynamics/video_recorder/recorder/states.js
@@ -953,7 +953,7 @@ Scoped.define("module:VideoRecorder.Dynamics.RecorderStates.Trimming", [
                     this.listenOnce(this.dyn, "manual-trim", function(start, end) {
                         if (Types.isNumber(start) && start > 0) this.dyn.set("starttime", start);
                         if (Types.isNumber(end) && end <= this.get("duration")) this.dyn.set("endtime", end);
-                        this.dyn.trigger("video-trimmed", this.dyn.get("starttime"), this.dyn.get("endtime"));
+                        this.dyn.trigger("video-trimmed", this.dyn.get("starttime"), this.dyn.get("endtime"), this.dyn.get("duration"));
                         this.next("Uploading");
                     });
                 }


### PR DESCRIPTION
When `allowtrim` is set to true the recorded or uploaded video can be trimmed with our trimming overlay, which uses the video player dynamic. Some users may want to use their own interface for trimming video, so this PR was created to address this use case. It introduces the following changes:
- Added new boolean parameter `trimoverlay` to allow user to hide trimming overlay. Default value is true, when set to false trimming happens by calling the trim method.
- Added new `trim` method for setting when trimmed video should start and end.
- Added new string `trim-video` that is shown when `trimoverlay` is set to false.
- Added new event `video-trimmed` which is triggered by the recorder after video is trimmed manually or using the trimming overlay. It returns trimming start and end time, as well as original video duration.
- Added new event `ready-to-trim` which is triggered by the recorder after it enters Trimming state.