### PR TITLE
Feature: pauseonclick parameter

### DIFF
--- a/src/dynamics/audio_player/player/player.html
+++ b/src/dynamics/audio_player/player/player.html
@@ -4,13 +4,15 @@
     {{cssplayer}}-{{title ? 'has-title' : 'no-title'}} {{visualeffectvisible ? cssplayer + '-visual-effect-applied' : ''}}"
 	ba-styles="{{widthHeightStyles}}"
 >
-	<canvas data-selector="audio-canvas" class="{{csstheme}}-audio-canvas"></canvas>
+	<canvas data-selector="audio-canvas" class="{{csstheme}}-audio-canvas" ba-on:click="{{toggle_player()}}"></canvas>
     <audio crossorigin="anonymous" tabindex="-1" class="{{css}}-audio" data-audio="audio"></audio>
     <div class="{{css}}-overlay">
 		<div tabindex="-1" class="{{css}}-player-toggle-overlay" data-selector="player-toggle-overlay"
 			 ba-hotkey:right="{{seek(position + skipseconds)}}" ba-hotkey:left="{{seek(position - skipseconds)}}"
 			 ba-hotkey:alt+right="{{seek(position + skipseconds * 3)}}" ba-hotkey:alt+left="{{seek(position - skipseconds * 3)}}"
 			 ba-hotkey:up="{{set_volume(volume + 0.1)}}" ba-hotkey:down="{{set_volume(volume - 0.1)}}"
+			 ba-hotkey:space^enter="{{toggle_player()}}"
+			 ba-on:click="{{toggle_player()}}"
 		></div>
 	    <ba-{{dyncontrolbar}}
 		    ba-css="{{csscontrolbar || css}}"

--- a/src/dynamics/audio_player/player/player.js
+++ b/src/dynamics/audio_player/player/player.js
@@ -76,6 +76,7 @@ Scoped.define("module:AudioPlayer.Dynamics.Player", [
                     /* Configuration */
                     "reloadonplay": false,
                     "playonclick": true,
+                    "pauseonclick": true,
                     /* Options */
                     "rerecordable": false,
                     "submittable": false,
@@ -127,6 +128,7 @@ Scoped.define("module:AudioPlayer.Dynamics.Player", [
                     "disablepause": "boolean",
                     "disableseeking": "boolean",
                     "playonclick": "boolean",
+                    "pauseonclick": "boolean",
                     "showsettings": "boolean",
                     "skipseconds": "integer",
                     "visualeffectvisible": "boolean",
@@ -497,6 +499,7 @@ Scoped.define("module:AudioPlayer.Dynamics.Player", [
                         // Draw visual effect
                         if (this.get('visualeffectsupported'))
                             this.audioVisualization.renderFrame();
+                        this.set("manuallypaused", false);
                     },
 
                     rerecord: function() {
@@ -604,6 +607,14 @@ Scoped.define("module:AudioPlayer.Dynamics.Player", [
 
                     toggle_settings_menu: function() {
                         this.set("settingsmenu_active", !this.get("settingsmenu_active"));
+                    },
+
+                    toggle_player: function() {
+                        if (this.get("playing") && this.get("pauseonclick")) {
+                            this.pause();
+                        } else if (!this.get("playing") && this.get("playonclick")) {
+                            this.play();
+                        }
                     }
 
                 },

--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -105,6 +105,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                     /* Configuration */
                     "reloadonplay": false,
                     "playonclick": true,
+                    "pauseonclick": true,
                     /* Ads */
                     "adprovider": null,
                     "preroll": false,
@@ -236,6 +237,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                     "disablepause": "boolean",
                     "disableseeking": "boolean",
                     "playonclick": "boolean",
+                    "pauseonclick": "boolean",
                     "airplay": "boolean",
                     "airplaybuttonvisible": "boolean",
                     "chromecast": "boolean",
@@ -1143,26 +1145,15 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                     },
 
                     toggle_player: function() {
-                        if (this.get('playing'))
-                            if (this.get("preventinteractionstatus")) return;
+                        if (this.get("playing") && this.get("preventinteractionstatus")) return;
                         if (this._delegatedPlayer) {
                             this._delegatedPlayer.execute("toggle_player");
                             return;
                         }
-                        if (!this.get("playonclick"))
-                            return;
-                        if (this.get('playing') && !this.get("disablepause")) {
-                            if (!this.get("volumeafterinteraction"))
-                                this.pause();
-                            else
-                                this.set("volumeafterinteraction", false);
-
-                            // If user paused the video and don't like player will auto-played
-                            // so, no need to play each time when user see video, also works for progress bar click
-                            this.set("manuallypaused", true);
-                        } else {
+                        if (this.get("playing") && this.get("pauseonclick")) {
+                            this.pause();
+                        } else if (!this.get("playing") && this.get("playonclick")) {
                             this.play();
-                            this.set("manuallypaused", false);
                         }
                     },
 


### PR DESCRIPTION
This PR introduces the following changes:
- **Video Player:** 
  - Added `pauseonclick` parameter and fixed issue with player not pausing on click
  - Removed some of the redundant code on `toggle_player` function
- **Audio Player:**
  - Added implementation for `playonclick` parameter - the parameter existed, but didn't do anything as it wasn't implemented yet
  - Added `pauseonclick` parameter
