### PR TITLE
Fix audio player breaking after request fail

### DIFF
--- a/src/dynamics/audio_player/player/states.js
+++ b/src/dynamics/audio_player/player/states.js
@@ -194,7 +194,7 @@ Scoped.define("module:AudioPlayer.Dynamics.PlayerStates.ErrorAudio", [
         _started: function() {
             this.dyn.set("message", this.dyn.string("audio-error"));
             this.listenOn(this.dyn, "message:click", function() {
-                this.next("LoadAudio");
+                this.next("Initial");
             }, this);
         }
 


### PR DESCRIPTION
When clicking to retry after the request for getting audio fails the audio player would freeze and stop working. This PR fixes the issue.