### PR TITLE
Minor changes to recorder duration

### DIFF
--- a/src/dynamics/audio_recorder/recorder/recorder.html
+++ b/src/dynamics/audio_recorder/recorder/recorder.html
@@ -94,7 +94,7 @@
         ba-data:id="player"
         ba-width="{{width}}"
         ba-height="{{height}}"
-        ba-totalduration="{{duration / 1000}}"
+        ba-totalduration="{{duration}}"
         ba-rerecordable="{{rerecordable && (recordings === null || recordings > 0)}}"
         ba-submittable="{{manualsubmit && verified}}"
         ba-reloadonplay="{{true}}"

--- a/src/dynamics/audio_recorder/recorder/recorder.js
+++ b/src/dynamics/audio_recorder/recorder/recorder.js
@@ -234,6 +234,8 @@ Scoped.define("module:AudioRecorder.Dynamics.Recorder", [
                         delay: 250,
                         start: true
                     });
+
+                    this._initSettings();
                 },
 
                 state: function() {
@@ -384,6 +386,10 @@ Scoped.define("module:AudioRecorder.Dynamics.Recorder", [
                     return this.recorder && this.recorder.isWebrtcStreaming();
                 },
 
+                _initSettings: function() {
+                    this.set("duration", 0);
+                },
+
                 _initializeUploader: function() {
                     if (this._dataUploader)
                         this._dataUploader.weakDestroy();
@@ -493,8 +499,10 @@ Scoped.define("module:AudioRecorder.Dynamics.Recorder", [
                     },
 
                     rerecord: function() {
-                        if (confirm(this.stringUnicode("rerecord-confirm")))
+                        if (confirm(this.stringUnicode("rerecord-confirm"))) {
                             this.host.state().rerecord();
+                            this._initSettings();
+                        }
                     },
 
                     stop: function() {
@@ -553,6 +561,7 @@ Scoped.define("module:AudioRecorder.Dynamics.Recorder", [
                         this._stopRecording().callback(function() {
                             this._unbindMedia();
                             this._detachRecorder();
+                            this._initSettings();
                             this.host.state().next("Initial");
                         }, this);
                     },

--- a/src/dynamics/audio_recorder/recorder/states.js
+++ b/src/dynamics/audio_recorder/recorder/states.js
@@ -587,7 +587,7 @@ Scoped.define("module:AudioRecorder.Dynamics.RecorderStates.Recording", [
         },
 
         _hasStopped: function() {
-            this.dyn.set("duration", Time.now() - this._startTime - this.__pauseDelta);
+            this.dyn.set("duration", (Time.now() - this._startTime - this.__pauseDelta) / 1000);
             this.dyn._unbindMedia();
             this.dyn.trigger("recording_stopped");
         }

--- a/src/dynamics/video_recorder/recorder/recorder.js
+++ b/src/dynamics/video_recorder/recorder/recorder.js
@@ -604,6 +604,7 @@ Scoped.define("module:VideoRecorder.Dynamics.Recorder", [
                     this.snapshots = [];
                     this.thumbnails = [];
                     this.__lastCovershotUpload = undefined;
+                    this.set("duration", 0);
                     this.set("videometadata", {
                         "height": null,
                         "width": null,


### PR DESCRIPTION
This PR introduces the following changes:

- Default value for `duration` on audio and video recorder is now 0 seconds.
- Audio recorder: changed duration of recorded audio from ms to s (to match uploaded audio duration / video recorder)
- Duration is now reset to 0 on `reset` and `rerecord`.