### PR TITLE
[Fix] Initial state on children

### DIFF
--- a/src/dynamics/audio_player/player/player.js
+++ b/src/dynamics/audio_player/player/player.js
@@ -216,7 +216,7 @@ Scoped.define("module:AudioPlayer.Dynamics.Player", [
                         stateRegistry: new ClassRegistry(this.cls.playerStates())
                     });
                     this.host.dynamic = this;
-                    this.host.initialize(InitialState);
+                    this.host.initialize(this._initialState);
 
                     this._timer = new Timers.Timer({
                         context: this,
@@ -225,6 +225,8 @@ Scoped.define("module:AudioPlayer.Dynamics.Player", [
                         start: true
                     });
                 },
+
+                _initialState: InitialState,
 
                 state: function() {
                     return this.host.state();

--- a/src/dynamics/audio_recorder/recorder/recorder.js
+++ b/src/dynamics/audio_recorder/recorder/recorder.js
@@ -227,7 +227,7 @@ Scoped.define("module:AudioRecorder.Dynamics.Recorder", [
                         stateRegistry: new ClassRegistry(this.cls.recorderStates())
                     });
                     this.host.dynamic = this;
-                    this.host.initialize(InitialState);
+                    this.host.initialize(this._initialState);
 
                     this._timer = new Timers.Timer({
                         context: this,
@@ -238,6 +238,8 @@ Scoped.define("module:AudioRecorder.Dynamics.Recorder", [
 
                     this._initSettings();
                 },
+
+                _initialState: InitialState,
 
                 state: function() {
                     return this.host.state();

--- a/src/dynamics/image_capture/capture/capture.js
+++ b/src/dynamics/image_capture/capture/capture.js
@@ -228,7 +228,7 @@ Scoped.define("module:ImageCapture.Dynamics.Recorder", [
                         stateRegistry: new ClassRegistry(this.cls.recorderStates())
                     });
                     this.host.dynamic = this;
-                    this.host.initialize(InitialState);
+                    this.host.initialize(this._initialState);
 
                     this._timer = new Timers.Timer({
                         context: this,
@@ -244,6 +244,8 @@ Scoped.define("module:ImageCapture.Dynamics.Recorder", [
                         this.set("orientation", false);
                     this.set("currentorientation", window.innerHeight > window.innerWidth ? "portrait" : "landscape");
                 },
+
+                _initialState: InitialState,
 
                 state: function() {
                     return this.host.state();

--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -542,7 +542,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                         stateRegistry: new ClassRegistry(this.cls.playerStates())
                     });
                     this.host.dynamic = this;
-                    this.host.initialize(InitialState);
+                    this.host.initialize(this._initialState);
 
                     this._timer = new Timers.Timer({
                         context: this,
@@ -574,6 +574,8 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                         }, this);
                     }
                 },
+
+                _initialState: InitialState,
 
                 state: function() {
                     return this.host.state();

--- a/src/dynamics/video_recorder/recorder/recorder.js
+++ b/src/dynamics/video_recorder/recorder/recorder.js
@@ -452,7 +452,7 @@ Scoped.define("module:VideoRecorder.Dynamics.Recorder", [
                         stateRegistry: new ClassRegistry(this.cls.recorderStates())
                     });
                     this.host.dynamic = this;
-                    this.host.initialize(InitialState);
+                    this.host.initialize(this._initialState);
 
                     this._timer = new Timers.Timer({
                         context: this,
@@ -480,6 +480,8 @@ Scoped.define("module:VideoRecorder.Dynamics.Recorder", [
                     this.set("currentorientation", window.innerHeight > window.innerWidth ? "portrait" : "landscape");
                     this._screenRecorderVerifier();
                 },
+
+                _initialState: InitialState,
 
                 state: function() {
                     return this.host.state();


### PR DESCRIPTION
It was not possible to override the InitialState on child dynamics. This PR fixes this.