### PR TITLE
[Video Player] Add hidecontrolbar type

### DIFF
--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -245,6 +245,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                 types: {
                     "allowpip": "boolean",
                     "hasnext": "boolean",
+                    "hidecontrolbar": "boolean",
                     "rerecordable": "boolean",
                     "loop": "boolean",
                     "loopall": "boolean",


### PR DESCRIPTION
This allow us to use the attribute by calling `<ba-videoplayer ... ba-hidecontrolbar></ba-videoplayer>` instead of `<ba-videoplayer ... ba-hidecontrolbar=true></ba-videoplayer>`.