### PR TITLE
[Video Player] Change default aspect ratio from 4:3 to 16:9

### DIFF
--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -78,8 +78,8 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                         "popup-width": "",
                         "popup-height": "",
                         "aspectratio": null,
-                        "fallback-width": 320,
-                        "fallback-height": 240,
+                        "fallback-width": 480,
+                        "fallback-height": 270,
                         /* Themes */
                         "theme": "",
                         "csstheme": "",


### PR DESCRIPTION
16:9 videos are more common than 4:3, so changing the default value will cause less size "jumping" issues.