### PR TITLE
[Fix] [Video Player] Add sticky classes on correct element

### DIFF
--- a/src/dynamics/_common/sticky_handler.js
+++ b/src/dynamics/_common/sticky_handler.js
@@ -19,6 +19,7 @@ Scoped.define("module:StickyHandler", [
                 this.element = element;
                 this.container = container;
                 this.paused = options.paused || false;
+                this.position = options.position || "bottom-right";
                 this.events = this.auto_destroy(new DomEvents());
             },
 
@@ -66,6 +67,8 @@ Scoped.define("module:StickyHandler", [
                         }
                         if (entry.isIntersecting || this.paused) return;
                         this.trigger("elementLeftView");
+                        if (!this.elementWasDragged()) this.element.classList.add("ba-commoncss-fade-up");
+                        this.element.classList.add("ba-commoncss-sticky", "ba-commoncss-sticky-" + this.position);
                         if (this._top) this.element.style.top = this._top;
                         if (this._left) this.element.style.left = this._left;
                         this._initEventListeners();
@@ -82,6 +85,7 @@ Scoped.define("module:StickyHandler", [
                         this.trigger("containerEnteredView");
                         this.element.style.removeProperty("top");
                         this.element.style.removeProperty("left");
+                        this.element.classList.remove("ba-commoncss-sticky", "ba-commoncss-sticky-" + this.position, "ba-commoncss-fade-up");
                         this.events.off(this.element, "mousedown touchstart");
                         this.dragging = false;
                     }.bind(this));

--- a/src/dynamics/video_player/player/player.html
+++ b/src/dynamics/video_player/player/player.html
@@ -2,9 +2,6 @@
      class="{{css}}-container {{cssplayer}}-size-{{csssize}} {{iecss}}-{{ie8 ? 'ie8' : 'noie8'}} {{csstheme}}
      {{cssplayer}}-{{fullscreened ? 'fullscreen' : 'normal'}}-view {{cssplayer}}-{{firefox ? 'firefox' : 'common'}}-browser
      {{cssplayer}}-{{themecolor}}-color {{cssplayer}}-device-type-{{mobileview ? 'mobile' : 'desktop'}}
-     {{sticktoview ? csscommon + '-sticky' : ''}}
-     {{sticktoview && fadeup ? csscommon + '-fade-up' : ''}}
-     {{sticktoview ? csscommon + '-sticky-' + stickypositioncss : ''}}
      {{csscommon}}-full-width
      {{cssplayer + (((activity_delta > hidebarafter) && hideoninactivity) ? '-controlbar-hidden' : '-controlbar-visible')}}"
      ba-on:mousemove="{{user_activity()}}"

--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -966,6 +966,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                             this._error("poster");
                         }, this);
                         this.player.on("playing", function() {
+                            if (this.get("sticky")) this.stickyHandler.start();
                             this.set("playing", true);
                             this.trigger("playing");
                             if (this.get("playedonce") === false) {

--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -412,7 +412,6 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                     }.bind(this));
                     this._observer.observe(this.activeElement());
                     this._validateParameters();
-                    this.set("stickypositioncss", this.get("sticky-position"));
                     // Will set volume initial state
                     this.set("initialoptions", Objs.tree_merge(this.get("initialoptions"), {
                         volumelevel: this.get("volume"),
@@ -533,7 +532,8 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
 
                     if (this.get("sticky")) {
                         var stickyOptions = {
-                            paused: true
+                            paused: true,
+                            position: this.get("sticky-position")
                         };
                         this.stickyHandler = this.auto_destroy(new StickyHandler(
                             this.activeElement().firstChild,
@@ -541,14 +541,6 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                             stickyOptions
                         ));
                         this.stickyHandler.init();
-                        this.set("fadeup", true);
-                        this.stickyHandler.on("elementLeftView", function() {
-                            this.set("sticktoview", true);
-                        }, this);
-                        this.stickyHandler.on("containerEnteredView", function() {
-                            this.set("sticktoview", false);
-                            if (this.get("fadeup") && this.stickyHandler.elementWasDragged()) this.set("fadeup", false);
-                        }, this);
                     }
                 },
 

--- a/src/dynamics/video_player/player/states.js
+++ b/src/dynamics/video_player/player/states.js
@@ -410,7 +410,6 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PosterReady", [
 
         play: function() {
             this.dyn.set("silent_attach", false);
-            if (this.dyn.get("sticky")) this.dyn.stickyHandler.start();
             if (!this.dyn.get("popup")) {
                 this.next("Preroll");
                 return;


### PR DESCRIPTION
Sticky classes weren't being added to the correct element if the player template was modified. This PR fixes this issue.