### PR TITLE
[Fix] Sticky player sizing

### DIFF
--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -394,7 +394,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                             aspectRatio: aspectRatio
                         };
                         if (height) styles.height = typeof height === "string" && height[height.length - 1] === "%" ? height : height + "px";
-                        if (width) styles.width = typeof width === "string" && width[width.length - 1] === "%" ? width : width + "px";
+                        if (width && width !== "100%") styles.width = typeof width === "string" && width[width.length - 1] === "%" ? width : width + "px";
                         if (this.activeElement()) {
                             this._applyStyles(this.activeElement(), styles, this.__lastContainerSizingStyles);
                         }

--- a/src/themes/_common/sticky.scss
+++ b/src/themes/_common/sticky.scss
@@ -46,16 +46,11 @@ div.#{$csscommon}-sticky {
 
 .#{$csscommon}-sticky {
     width: 360px;
+    max-width: 100%;
     animation: #{$csscommon}-fade-in 0.75s ease forwards;
 }
 
 .#{$csscommon}-fade-up {
     transform: translateY(100%);
     animation: #{$csscommon}-fade-in-up 0.75s ease forwards;
-}
-
-@media (max-width: 980px) {
-    .#{$csscommon}-sticky {
-        max-width: 50%;
-    }
 }


### PR DESCRIPTION
Width 100% as inline style overrides the width from the sticky class. We are already adding width 100% to the player through the `ba-commoncss-full-width` class, so no need to do it inline as well.

This PR also does the following:
- Set max-width to 100% on sticky player
- Remove media query from sticky player limiting width to 50%