### PR TITLE
[Fix] Volume issues linked to ad playback

### DIFF
--- a/src/dynamics/ads_player/ads_controlbar/ads_controlbar.js
+++ b/src/dynamics/ads_player/ads_controlbar/ads_controlbar.js
@@ -65,12 +65,12 @@ Scoped.define("module:Ads.Dynamics.Controlbar", [
                             if (domRect.width > domRect.height) {
                                 // Horizontal slider
                                 var x = event.clientX;
-                                if (!x && Array.isArray(event.touches)) x = event.touches[0].clientX;
+                                if (!x && event.touches) x = event.touches[0].clientX;
                                 volume = Maths.clamp((x - domRect.x) / domRect.width, 0, 1);
                             } else {
                                 // Vertical slider
                                 var y = event.clientY;
-                                if (!y && Array.isArray(event.touches)) y = event.touches[0].clientY;
+                                if (!y && event.touches) y = event.touches[0].clientY;
                                 volume = Maths.clamp((domRect.bottom - y) / domRect.height, 0, 1);
                             }
                             this.trigger("volume", volume);

--- a/src/dynamics/ads_player/ads_controlbar/ads_controlbar.js
+++ b/src/dynamics/ads_player/ads_controlbar/ads_controlbar.js
@@ -60,19 +60,20 @@ Scoped.define("module:Ads.Dynamics.Controlbar", [
                         event.preventDefault();
 
                         var updateVolume = function(event) {
+                            var volume;
                             event.preventDefault();
                             if (domRect.width > domRect.height) {
                                 // Horizontal slider
                                 var x = event.clientX;
                                 if (!x && Array.isArray(event.touches)) x = event.touches[0].clientX;
-                                this.set("volume", Maths.clamp((x - domRect.x) / domRect.width, 0, 1));
+                                volume = Maths.clamp((x - domRect.x) / domRect.width, 0, 1);
                             } else {
                                 // Vertical slider
                                 var y = event.clientY;
                                 if (!y && Array.isArray(event.touches)) y = event.touches[0].clientY;
-                                this.set("volume", Maths.clamp((domRect.bottom - y) / domRect.height, 0, 1));
+                                volume = Maths.clamp((domRect.bottom - y) / domRect.height, 0, 1);
                             }
-                            this.trigger("volume", this.get("volume"));
+                            this.trigger("volume", volume);
                         }.bind(this);
 
                         updateVolume(event);
@@ -108,8 +109,12 @@ Scoped.define("module:Ads.Dynamics.Controlbar", [
                     toggle_volume: function() {
                         if (this.get("unmuteonclick")) return;
                         var volume = this.get("volume");
-                        if (volume > 0) this.__lastVolume = volume;
-                        volume = volume > 0 ? 0 : (this.__lastVolume || 1);
+                        if (volume > 0) {
+                            this.__oldVolume = volume;
+                            volume = 0;
+                        } else {
+                            volume = this.__oldVolume || 1;
+                        }
                         this.trigger("volume", volume);
                     },
 

--- a/src/dynamics/ads_player/ads_player.js
+++ b/src/dynamics/ads_player/ads_player.js
@@ -50,7 +50,7 @@ Scoped.define("module:Ads.Dynamics.Player", [
                         if (volume > 0 && this.get("unmuteonclick")) {
                             return setTimeout(function() {
                                 this.adsManager.setVolume(Maths.clamp(volume, 0, 1));
-                            }.bind(this));
+                            }.bind(this), 200);
                         } else {
                             return this.adsManager.setVolume(Maths.clamp(volume, 0, 1));
                         }

--- a/src/dynamics/ads_player/ads_player.js
+++ b/src/dynamics/ads_player/ads_player.js
@@ -47,15 +47,6 @@ Scoped.define("module:Ads.Dynamics.Player", [
                         // Muted should be pass only from the parent
                         this.parent().set('muted', volume <= 0);
                         if (!this.adsManager || !this.adsManager.setVolume) return;
-                        // In some cases ads:volumeChange is not triggering
-                        Async.eventually(function() {
-                            if (!this.__volumeChangeTriggered) {
-                                var adsVolume = this.adsManager.getVolume();
-                                this.set("volume", adsVolume);
-                                this.parent().set("muted", adsVolume <= 0);
-                                this.__volumeChangeTriggered = false;
-                            }
-                        }, this, 100);
                         if (volume > 0 && this.get("unmuteonclick")) {
                             return setTimeout(function() {
                                 this.adsManager.setVolume(Maths.clamp(volume, 0, 1));
@@ -147,12 +138,6 @@ Scoped.define("module:Ads.Dynamics.Player", [
                         this.set("duration", event.getAdData().duration);
                         this.set("moredetailslink", event.getAdData().clickThroughUrl);
                         this.set("adsclicktroughurl", event.getAdData().clickThroughUrl);
-                    },
-                    "ads:volumeChange": function() {
-                        this.__volumeChangeTriggered = true;
-                        var adsVolume = this.adsManager.getVolume();
-                        this.set("volume", adsVolume);
-                        this.parent().set("muted", adsVolume <= 0);
                     },
                     "ads:outstreamCompleted": function(dyn) {
                         this._outstreamCompleted(dyn);

--- a/src/dynamics/ads_player/ads_player.js
+++ b/src/dynamics/ads_player/ads_player.js
@@ -293,7 +293,7 @@ Scoped.define("module:Ads.Dynamics.Player", [
                         return this.adsManager.resume();
                     },
                     set_volume: function(volume) {
-                        this.set("volume", volume);
+                        this.set("volume", Maths.clamp(volume, 0, 1));
                     },
                     stop: function() {
                         return this.adsManager.stop();

--- a/src/dynamics/video_player/controlbar/controlbar.js
+++ b/src/dynamics/video_player/controlbar/controlbar.js
@@ -194,19 +194,20 @@ Scoped.define("module:VideoPlayer.Dynamics.Controlbar", [
                         event.preventDefault();
 
                         var updateVolume = function(event) {
+                            var volume;
                             event.preventDefault();
                             if (domRect.width > domRect.height) {
                                 // Horizontal slider
                                 var x = event.clientX;
                                 if (!x && Array.isArray(event.touches)) x = event.touches[0].clientX;
-                                this.set("volume", Maths.clamp((x - domRect.x) / domRect.width, 0, 1));
+                                volume = Maths.clamp((x - domRect.x) / domRect.width, 0, 1);
                             } else {
                                 // Vertical slider
                                 var y = event.clientY;
                                 if (!y && Array.isArray(event.touches)) y = event.touches[0].clientY;
-                                this.set("volume", Maths.clamp((domRect.bottom - y) / domRect.height, 0, 1));
+                                volume = Maths.clamp((domRect.bottom - y) / domRect.height, 0, 1);
                             }
-                            this.trigger("volume", this.get("volume"));
+                            this.trigger("volume", volume);
                         }.bind(this);
 
                         updateVolume(event);
@@ -247,13 +248,14 @@ Scoped.define("module:VideoPlayer.Dynamics.Controlbar", [
 
                     toggle_volume: function() {
                         if (this.get("unmuteonclick") && !this.get("userhadplayerinteraction")) return;
-                        if (this.get("volume") > 0) {
-                            this.__oldVolume = this.get("volume");
-                            this.set("volume", 0);
+                        var volume = this.get("volume");
+                        if (volume > 0) {
+                            this.__oldVolume = volume;
+                            volume = 0;
                         } else {
-                            this.set("volume", this.__oldVolume || 1);
+                            volume = this.__oldVolume || 1;
                         }
-                        this.trigger("volume", this.get("volume"));
+                        this.trigger("volume", volume);
                     },
 
                     toggle_position_info: function() {

--- a/src/dynamics/video_player/controlbar/controlbar.js
+++ b/src/dynamics/video_player/controlbar/controlbar.js
@@ -199,12 +199,12 @@ Scoped.define("module:VideoPlayer.Dynamics.Controlbar", [
                             if (domRect.width > domRect.height) {
                                 // Horizontal slider
                                 var x = event.clientX;
-                                if (!x && Array.isArray(event.touches)) x = event.touches[0].clientX;
+                                if (!x && event.touches) x = event.touches[0].clientX;
                                 volume = Maths.clamp((x - domRect.x) / domRect.width, 0, 1);
                             } else {
                                 // Vertical slider
                                 var y = event.clientY;
-                                if (!y && Array.isArray(event.touches)) y = event.touches[0].clientY;
+                                if (!y && event.touches) y = event.touches[0].clientY;
                                 volume = Maths.clamp((domRect.bottom - y) / domRect.height, 0, 1);
                             }
                             this.trigger("volume", volume);

--- a/src/dynamics/video_player/controlbar/controlbar.js
+++ b/src/dynamics/video_player/controlbar/controlbar.js
@@ -279,7 +279,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Controlbar", [
                     },
 
                     set_volume: function(volume) {
-                        this.trigger("set_volume", volume);
+                        this.trigger("volume", volume);
                     },
 
                     submit: function() {

--- a/src/dynamics/video_player/player/player.html
+++ b/src/dynamics/video_player/player/player.html
@@ -140,7 +140,6 @@
                 ba-event:toggle_player="toggle_player"
                 ba-event:tab_index_move="tab_index_move"
                 ba-event:seek="seek"
-                ba-event:set_volume="set_volume"
                 ba-event:toggle_tracks="toggle_tracks"
                 ba-tabindex="{{tabindex}}"
                 ba-showchaptertext="{{showchaptertext}}"

--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -14,6 +14,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
     "base:Objs",
     "base:Strings",
     "base:Collections.Collection",
+    "base:Maths",
     "base:Time",
     "base:Timers",
     "base:Promise",
@@ -64,7 +65,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
     "module:VideoPlayer.Dynamics.PlayerStates.ErrorVideo",
     "module:VideoPlayer.Dynamics.PlayerStates.PlayVideo",
     "module:VideoPlayer.Dynamics.PlayerStates.NextVideo"
-], function(Class, Assets, DatasetProperties, StickyHandler, StylesMixin, TrackTags, Info, Dom, VideoPlayerWrapper, Broadcasting, PlayerSupport, Types, Objs, Strings, Collection, Time, Timers, Promise, TimeFormat, Host, ClassRegistry, Async, InitialState, PlayerStates, AdProvider, DomEvents, scoped) {
+], function(Class, Assets, DatasetProperties, StickyHandler, StylesMixin, TrackTags, Info, Dom, VideoPlayerWrapper, Broadcasting, PlayerSupport, Types, Objs, Strings, Collection, Maths, Time, Timers, Promise, TimeFormat, Host, ClassRegistry, Async, InitialState, PlayerStates, AdProvider, DomEvents, scoped) {
     return Class.extend({
             scoped: scoped
         }, [StylesMixin, function(inherited) {
@@ -545,6 +546,13 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                                 this.channel("next").trigger("autoPlayNext");
                                 this.channel("next").trigger("playNext");
                             }
+                        }
+                    },
+                    "change:volume": function(volume) {
+                        if (this.isBroadcasting()) this._broadcasting.player.trigger("change-google-cast-volume", volume);
+                        if (this.videoLoaded()) {
+                            this.player.setVolume(volume);
+                            this.player.setMuted(volume <= 0);
                         }
                     }
                 },
@@ -1773,15 +1781,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                             this._delegatedPlayer.execute("set_volume", volume);
                             return;
                         }
-                        volume = Math.min(1.0, volume);
-
-                        if (this.isBroadcasting()) this._broadcasting.player.trigger("change-google-cast-volume", volume);
-
-                        this.set("volume", volume);
-                        if (this.videoLoaded()) {
-                            this.player.setVolume(volume);
-                            this.player.setMuted(volume <= 0);
-                        }
+                        this.set("volume", Maths.clamp(volume, 0, 1));
                     },
 
                     toggle_settings_menu: function() {

--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -1775,9 +1775,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                         }
                         volume = Math.min(1.0, volume);
 
-                        if (this.player && this.player._broadcastingState && this.player._broadcastingState.googleCastConnected) {
-                            this._broadcasting.player.trigger("change-google-cast-volume", volume);
-                        }
+                        if (this.isBroadcasting()) this._broadcasting.player.trigger("change-google-cast-volume", volume);
 
                         this.set("volume", volume);
                         if (this.videoLoaded()) {
@@ -2204,6 +2202,10 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                     return Objs.map(Types.is_function(this.attrs) ? this.attrs.call(this) : this.attrs, function(value, key) {
                         return this.get(key);
                     }, this);
+                },
+
+                isBroadcasting: function() {
+                    return this.player && this.player._broadcastingState && this.player._broadcastingState.googleCastConnected;
                 },
 
                 isHD: function() {

--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -2690,7 +2690,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                                 // If user not paused video manually, we set user as engaged
                                 if (!this.get("manuallypaused")) this.__setPlayerEngagement();
                                 if (this.player) this.player.setMuted(false);
-                                this.set_volume(this.get("initialoptions").volumelevel);
+                                this.set_volume(this.get("volume") || this.get("initialoptions").volumelevel);
                             }
                             this.set("unmuteonclick", false);
                         }.bind(this),


### PR DESCRIPTION
This PR refactors how volume changes are applied, fixing the following issues:
- Sound plays for a fraction of a second when an ad is paused and unmuteonclick is enabled
- Sound changes during ad playback aren't reflected on main video content
- Volume slider on jumps around when sliding during ad playback