### PR TITLE
[Fix] Sticky Handler unpauses on video transition

### DIFF
--- a/src/dynamics/_common/sticky_handler.js
+++ b/src/dynamics/_common/sticky_handler.js
@@ -45,6 +45,7 @@ Scoped.define("module:StickyHandler", [
             },
 
             start: function() {
+                if (this.floatCondition && !this.floatCondition()) return;
                 if (!this.elementIsVisible && !this.floating) this.transitionToFloat();
                 this.paused = false;
             },


### PR DESCRIPTION
Issue can be reproduced with the following attributes:
```
sticky: true,
floatingoptions: {
  noFloatOnDesktop: true,
  noFloatOnMobile: true
}
```