### PR TITLE
show/hide buttons on endcards options

### DIFF
--- a/demos/embed/ad-ima-player.html
+++ b/demos/embed/ad-ima-player.html
@@ -134,7 +134,6 @@
                 // allowRepeat: false,
                 // hideclose: false,
                 // repeatText: "repeatText"
-                // moredetailslink: "moreDetailsLink"
             },
             // visibilityfraction: 0.01,
             // adsposition: "pre, mid, post",

--- a/demos/embed/ad-ima-player.html
+++ b/demos/embed/ad-ima-player.html
@@ -126,12 +126,13 @@
             // outstream: true,
             adchoiceslink: 'https://ziggeo.com/privacy/',
             outstreamoptions: {
-                // moreURL: "https://ziggeo.com",
+                // moredetailslink: "https://ziggeo.com",
                 // moreText: "Read more about Ziggeo",
                 // hideOnCompletion: true,
                 // corner: false
                 // corner: "30px",
                 // allowRepeat: false,
+                // hideclose: false,
                 // repeatText: "repeatText"
             },
             // visibilityfraction: 0.01,

--- a/demos/embed/test-player.html
+++ b/demos/embed/test-player.html
@@ -188,7 +188,8 @@
                 recurrenceperiod: 5000, // Period when a new request will be sent if ads is not showing, default: 30 seconds
                 // maxadstoshow: -1 // Maximum number of ads to show; default: -1 (unlimited)
                 // maxadstoshow: 0 // Maximum number of ads to show; default: -1 (unlimited)
-                // moreURL: "https://ziggeo.com",
+                // moredetailslink: "https://ziggeo.com",
+                // hideclose: false,
                 moreText: "Read more about Ziggeo",
                 hideOnCompletion: false,
                 // corner: false

--- a/src/dynamics/ads_player/ads_player.html
+++ b/src/dynamics/ads_player/ads_player.html
@@ -33,7 +33,7 @@
                 {{repeatbuttontext ? repeatbuttontext : string('replay-ad')}}
             </button>
         </div>
-        <div>
+        <div ba-if="{{!hideclosebutton}}">
             <button class="{{cssadsplayer}}-action-button {{cssadsplayer}}-reversed-color"
                  title="{{string('close-ad')}}" ba-click="{{close()}}"
             >

--- a/src/dynamics/ads_player/ads_player.js
+++ b/src/dynamics/ads_player/ads_player.js
@@ -32,6 +32,8 @@ Scoped.define("module:Ads.Dynamics.Player", [
                     hidecontrolbar: false,
                     showactionbuttons: false,
                     showrepeatbutton: true,
+                    showlearnmore: false,
+                    hideclosebutton: false,
                     adscompleted: false,
                     moredetailslink: null,
                     moredetailstext: null,
@@ -414,19 +416,20 @@ Scoped.define("module:Ads.Dynamics.Player", [
                             this._hideContentPlayer(dyn);
                             return;
                         } else {
+                            const moreDetailsLink = dyn.get("outstreamoptions.moredetailslink");
                             if (dyn.get("outstreamoptions.noEndCard")) return;
-                            if (dyn.get("outstreamoptions.moreURL")) {
-                                this.set("moredetailslink", dyn.get("outstreamoptions.moreURL"));
-                            }
                             if (dyn.get("outstreamoptions.moreText")) {
                                 this.set("moredetailstext", dyn.get("outstreamoptions.moreText"));
                             }
-                            if (dyn.get("outstreamoptions.allowRepeat")) {
-                                this.set("showrepeatbutton", !!dyn.get("outstreamoptions.allowRepeat"));
-                            }
+                            this.set("showrepeatbutton", !!dyn.get("outstreamoptions.allowRepeat"));
                             if (dyn.get("outstreamoptions.repeatText")) {
                                 this.set("repeatbuttontext", dyn.get("outstreamoptions.repeatText"));
                             }
+                            if (moreDetailsLink) {
+                                this.set("moredetailslink", moreDetailsLink);
+                            }
+                            this.set("hideclosebutton", !!dyn.get("outstreamoptions.hideclose"));
+                            this.set("showlearnmorebutton", !!dyn.get("outstreamoptions.showlearnmore"));
                         }
                     }
                     this.set("showactionbuttons", true);

--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -360,7 +360,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                                 maxadstoshow: -1, // Maximum number of ads to show, if there's next ads or errors occurred default: -1 (unlimited)
                                 noEndCard: false, // No end cart at the end when outstream completed
                                 allowRepeat: true, // Make possible to repeat ads
-                                // moreURL: '', // more button URL
+                                // moredetailslink: '', // more button URL
                                 // moreText: '', // read more about outstream text
                                 // repeatText: '', // repeat button text
                                 persistentcompanionad: false


### PR DESCRIPTION
# 📌 - Related Issue
- [KVID-483](https://kargo1.atlassian.net/browse/KVID-483)

# 🏹 - Proposed Changes
- refactored endcard options with added ability to individually show or hide the Learn More, Replay Ad, and Close buttons

# 🚨 - Schema Updates
- added `hideClose` and `showLearnMore` attributes in the attrs object when creating a `new KargoVideo.Player`

# 🚧 - Impacted Areas
- Endcard buttons

# 🎯 - Checklist
- [x] Tested locally
- [ ] Unit Test
- [ ] Add milestone, labels, reviewers

# 🗒️ - Demo
- [Local testing demo video](https://drive.google.com/file/d/1t6-VtMPvrh6-ET34IwCDuzL2V52fgJ5p/view?usp=sharing)