### PR TITLE
fix on text center at next/stay buttons

### DIFF
--- a/src/themes/_common/player/next.scss
+++ b/src/themes/_common/player/next.scss
@@ -40,7 +40,6 @@
     text-shadow: 0 1px 4px rgba(0,0,0,.25);
     position: relative;
     z-index: 1;
-    height: 30px;
   }
   hr {
     margin: 0;


### PR DESCRIPTION
ZIG-3663 text-of-stay-next-slightly-off-center-on-desktop