### PR TITLE
set duration from adData, so it can be calculated by progressbar

### DIFF
--- a/src/dynamics/ads_player/ads_controlbar/ads_controlbar.js
+++ b/src/dynamics/ads_player/ads_controlbar/ads_controlbar.js
@@ -32,6 +32,8 @@ Scoped.define("module:Ads.Dynamics.Controlbar", [
 
                 channels: {
                     "ads:adProgress": function(event) {
+                        if (!this.get("duration") || this.get("duration") == 0)
+                            this.set("duration", event.getAdData().duration);
                         this.set("currenttime", event.getAdData().currentTime);
                         this.set("remaining", this.get("duration") - event.getAdData().currentTime);
                     }


### PR DESCRIPTION
missing duration on the ads controlbar would make the progressbar not shown.