### PR TITLE
[ZIG-4834] fix clicking on the ads once instead of twice

### DIFF
--- a/src/dynamics/ads_player/ads_player.html
+++ b/src/dynamics/ads_player/ads_player.html
@@ -48,10 +48,6 @@
          data-selector="ba-ads-clickthrough-container"
          class="{{css}}-overlay {{csscommon}}-clickable"
     ></div>
-    <div ba-if="{{!userhadplayerinteraction && unmuteonclick && linear}}"
-         class="{{css}}-overlay {{cssadsplayer}}-ad-click-tracker {{csscommon}}-clickable"
-         ba-click="{{ad_clicked()}}"
-    ></div>
 </div>
 <ba-{{dyncontrolbar}}
     ba-if="{{!hidecontrolbar && linear && !showactionbuttons}}"

--- a/src/dynamics/ads_player/ads_player.js
+++ b/src/dynamics/ads_player/ads_player.js
@@ -289,11 +289,6 @@ Scoped.define("module:Ads.Dynamics.Player", [
                         // if (!this.adsManager.adDisplayContainerInitialized) this.adsManager.initializeAdDisplayContainer();
                         // this.call("requestAds");
                     },
-                    ad_clicked: function() {
-                        if (!this.get("userhadplayerinteraction")) {
-                            this.parent().set("userhadplayerinteraction", true);
-                        }
-                    },
                     reset: function() {
                         this.set("linear", true);
                         this.set("adscompleted", true);


### PR DESCRIPTION
## Proposed changes
I remove  the cover or overlap  on the player that prevent first click through  

## Dependencies
- Update this if the PR requires us to update the project’s dependencies

## Checklist
- [X] Tested locally
- [ ] Added new unit, integration or regression tests
- [ ] Updated docs

## Demo
- Add before and after screenshots and videos showcasing the changes
