### PR TITLE
ZIG-4904: Fix floating sidebar background color

### DIFF
--- a/src/themes/_common/player/floating-with-sidebar.scss
+++ b/src/themes/_common/player/floating-with-sidebar.scss
@@ -33,9 +33,9 @@ div.#{$cssplayer}-with-sidebar {
         }
         .#{$cssfloatingsidebar}-content-container {
             height: 100%;
-            margin-left: 7px;
-            margin-top: 11px;
-            margin-right: 18px;
+            padding-left: 7px;
+            padding-top: 11px;
+            padding-right: 18px;
             text-align: left;
             word-wrap: break-word;
         }


### PR DESCRIPTION
Switched container to padding from margin to align container to fit exactly to size of sidebar

## Proposed changes
- List an overview of the changes included in this PR

## Dependencies
- Update this if the PR requires us to update the project’s dependencies

## Checklist
- [ ] Tested locally
- [ ] Added new unit, integration or regression tests
- [ ] Updated docs

## Demo
- Add before and after screenshots and videos showcasing the changes
