### PR TITLE
[ZIG-4788] ignored the autoplaywhenvisible param when floatingonly is enable

### DIFF
--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -829,6 +829,9 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                         hidden,
                         hidebeforeadstarts
                     ) {
+                        if (this.get("floatingoptions.floatingonly")) {
+                            this.set("autoplaywhenvisible", false);
+                        }
                         if (hidden) return hidden;
                         if (!autoplay && !autoplaywhenvisible) return false;
                         if (hidebeforeadstarts && adshassource) return !adsinitialized;


### PR DESCRIPTION
## Proposed changes
-  Ignored the autoplaywhenvisible param when floatingonly is enable

## Dependencies
-

## Checklist
- [ ] Tested locally

## Demo
- 
