### PR TITLE
KVID-594: Support fetching Companion ad slots from Shadow DOM

### DIFF
--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -3189,13 +3189,17 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                         const {
                             selector,
                             id,
-                            adslotid
+                            adslotid,
+                            incontainer
                         } = location;
                         if (!selector || !(id || adslotid)) {
                             console.warn(`Please provide selector and adslotid for companion ad`);
                             return;
                         }
-                        const element = document.querySelector(selector);
+                        let element = document.querySelector(selector);
+                        if (!element && incontainer) {
+                            element = this.activeElement().querySelector(selector);
+                        }
                         if (element) {
                             Objs.map(companionAds, function(ad) {
                                 const adContent = ad.data?.content;

--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -3196,8 +3196,10 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                             console.warn(`Please provide selector and adslotid for companion ad`);
                             return;
                         }
-                        let element = document.querySelector(selector);
-                        if (!element && incontainer) {
+                        let element;
+                        if (!incontainer) {
+                            element = document.querySelector(selector);
+                        } else {
                             element = this.activeElement().querySelector(selector);
                         }
                         if (element) {


### PR DESCRIPTION
## Proposed changes
- Adds functionality to render Companion banners to ad slots within the shadow DOM.

## Dependencies
- Used by Video Kargo Player PR https://github.com/KargoGlobal/video-kargo-player/pull/541

## Checklist
- [x] Tested locally
- [] Added new unit, integration or regression tests
- [] Updated docs
  - Let me know what docs need to be updated. 

## Demo
- See https://github.com/KargoGlobal/video-kargo-player/pull/541
