### PR TITLE
additional call for function to set nextIndex to prevent it skipping …

### DIFF
--- a/src/dynamics/video_player/sidebar/sidebar.js
+++ b/src/dynamics/video_player/sidebar/sidebar.js
@@ -463,6 +463,8 @@ Scoped.define("module:VideoPlayer.Dynamics.Sidebar", [
                             display: true,
                             scroll: true
                         });
+                        if (!_.get("loading"))
+                            _.setNextVideoIndex();
                         _.get("loaded").push(index);
                     }
                     image.onerror = function() {


### PR DESCRIPTION
…video from sidebar.

## Proposed changes
- Adding call to setNextVideoIndex on loaded image, because previously it'll skip unloaded poster thus skipping the video altogether.

## Dependencies
- No dependency

## Checklist
- [x] Tested locally
- [ ] Added new unit, integration or regression tests
- [ ] Updated docs

## Demo
- Add before and after screenshots and videos showcasing the changes
