### PR TITLE
[ZIG-5243] Fix ads play muted when content is not

### DIFF
--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -1001,6 +1001,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                         this.on("change:adsplaying", function(adsplaying) {
                             if (adsplaying) {
                                 this.set("unmuteonclick", false);
+                                if (this.get("volume") > 0) this.set("adsunmuted", true);
                             } else if (this.get("muted") || this.get("volume") === 0) {
                                 this.set("unmuteonclick", true);
                             }


### PR DESCRIPTION
## Proposed changes
- Fix ads play muted when content is not

## Dependencies
- Update this if the PR requires us to update the project’s dependencies

## Checklist
- [X] Tested locally
- [ ] Added new unit, integration or regression tests
- [ ] Updated docs

## Demo
- Add before and after screenshots and videos showcasing the changes
