### PR TITLE
ZIG-5216: Remove custom click tracking element and fix inlinevastxml

### DIFF
--- a/src/ads/ima/manager.js
+++ b/src/ads/ima/manager.js
@@ -50,7 +50,7 @@ Scoped.define("module:Ads.IMA.AdsManager", [
                 }
 
                 // boolean: Sets whether to disable custom playback on iOS 10+ browsers. If true, ads will play inline if the content video is inline.
-                if (settings.isMobile) {
+                if (settings.iOS10Plus) {
                     google.ima.settings.setDisableCustomPlaybackForIOS10Plus(true);
                 }
 

--- a/src/ads/ima/manager.js
+++ b/src/ads/ima/manager.js
@@ -18,9 +18,7 @@ Scoped.define("module:Ads.IMA.AdsManager", [
 
                 if (google && google.ima && options.IMASettings)
                     this._setIMASettings(options);
-                this._adDisplayContainer = new google.ima.AdDisplayContainer(
-                    options.adContainer, options.videoElement, options.customclickthrough || null
-                );
+                this._adDisplayContainer = new google.ima.AdDisplayContainer(options.adContainer, options.videoElement);
                 this._adsLoader = new google.ima.AdsLoader(this._adDisplayContainer);
                 this._adsLoader.addEventListener(google.ima.AdErrorEvent.Type.AD_ERROR, this.onAdError.bind(this), false);
                 this._adsLoader.addEventListener(google.ima.AdsManagerLoadedEvent.Type.ADS_MANAGER_LOADED, this.onAdsManagerLoaded.bind(this), false);
@@ -52,8 +50,8 @@ Scoped.define("module:Ads.IMA.AdsManager", [
                 }
 
                 // boolean: Sets whether to disable custom playback on iOS 10+ browsers. If true, ads will play inline if the content video is inline.
-                if (settings.disableCustomPlaybackForIOS10Plus) {
-                    google.ima.settings.setDisableCustomPlaybackForIOS10Plus(settings.disableCustomPlaybackForIOS10Plus);
+                if (settings.isMobile) {
+                    google.ima.settings.setDisableCustomPlaybackForIOS10Plus(true);
                 }
 
                 // string: Sets the publisher provided locale. Must be called before creating AdsLoader or AdDisplayContainer.
@@ -101,7 +99,7 @@ Scoped.define("module:Ads.IMA.AdsManager", [
                 }
 
                 // if size query param is not on the ad tag url, define them
-                if (!requestAdsOptions.adTagParams.sz || !requestAdsOptions.adTagParams.sz.length > 0) {
+                if (requestAdsOptions.adTagParams && !requestAdsOptions?.adTagParams?.sz.length > 0) {
                     this._adsRequest.linearAdSlotWidth = requestAdsOptions.linearAdSlotWidth;
                     this._adsRequest.linearAdSlotHeight = requestAdsOptions.linearAdSlotHeight;
                     this._adsRequest.nonLinearAdSlotWidth = requestAdsOptions.nonLinearAdSlotWidth;

--- a/src/ads/ima/manager.js
+++ b/src/ads/ima/manager.js
@@ -99,7 +99,7 @@ Scoped.define("module:Ads.IMA.AdsManager", [
                 }
 
                 // if size query param is not on the ad tag url, define them
-                if (requestAdsOptions.adTagParams && !requestAdsOptions?.adTagParams?.sz.length > 0) {
+                if (!requestAdsOptions?.adTagParams?.sz.length > 0) {
                     this._adsRequest.linearAdSlotWidth = requestAdsOptions.linearAdSlotWidth;
                     this._adsRequest.linearAdSlotHeight = requestAdsOptions.linearAdSlotHeight;
                     this._adsRequest.nonLinearAdSlotWidth = requestAdsOptions.nonLinearAdSlotWidth;

--- a/src/dynamics/ads_player/ads_player.html
+++ b/src/dynamics/ads_player/ads_player.html
@@ -45,10 +45,6 @@
             </button>
         </div>
     </div>
-    <div ba-if="{{ adsclicktroughurl && customclickthrough }}"
-         data-selector="ba-ads-clickthrough-container"
-         class="{{css}}-overlay {{csscommon}}-clickable"
-    ></div>
 </div>
 <ba-{{dyncontrolbar}}
     ba-if="{{!hidecontrolbar && linear && !showactionbuttons}}"

--- a/src/dynamics/ads_player/ads_player.js
+++ b/src/dynamics/ads_player/ads_player.js
@@ -336,13 +336,13 @@ Scoped.define("module:Ads.Dynamics.Player", [
                     const adManagerOptions = {
                         adContainer: adContainer,
                         adsRenderingSettings: this.get("imaadsrenderingsetting"),
-                        IMASettings: {
-                            ...this.get("imasettings"),
-                            ...{
-                                isMobile
-                            }
-                        }
+                        IMASettings: this.get("imasettings")
                     };
+
+                    if (isMobile && Info.iOSversion().major >= 10) {
+                        adManagerOptions.IMASettings.iOS10Plus = true;
+                    }
+
                     if (!isMobile && this.getVideoElement()) {
                         // It's optionalParameter
                         adManagerOptions.videoElement = this.getVideoElement();

--- a/src/dynamics/ads_player/ads_player.js
+++ b/src/dynamics/ads_player/ads_player.js
@@ -113,7 +113,6 @@ Scoped.define("module:Ads.Dynamics.Player", [
                     adsplaying: false,
                     companionads: [],
                     companionadcontent: null,
-                    customclickthrough: false,
                     persistentcompanionad: false,
                     ads_loaded: false,
                     ads_load_started: false
@@ -187,7 +186,7 @@ Scoped.define("module:Ads.Dynamics.Player", [
                     /** @type {RequestAdsOptions} */
                     const requestAdsOptions = {
                         adTagUrl: adTagUrl,
-                        adTagParams: this._adTagUrlParamsToMap(adTagUrl),
+                        adTagParams: adTagUrl && this._adTagUrlParamsToMap(adTagUrl),
                         IMASettings: this.get("imasettings"),
                         inlinevastxml: this.get("inlinevastxml"),
                         continuousPlayback: true,
@@ -332,18 +331,21 @@ Scoped.define("module:Ads.Dynamics.Player", [
 
                 create: function() {
                     const dynamics = this.parent();
+                    const isMobile = Info.isMobile();
                     const adContainer = this.getAdContainer();
                     const adManagerOptions = {
                         adContainer: adContainer,
                         adsRenderingSettings: this.get("imaadsrenderingsetting"),
-                        IMASettings: this.get("imasettings")
+                        IMASettings: {
+                            ...this.get("imasettings"),
+                            ...{
+                                isMobile
+                            }
+                        }
                     };
-                    if (!Info.isMobile() && this.getVideoElement()) {
+                    if (!isMobile && this.getVideoElement()) {
                         // It's optionalParameter
                         adManagerOptions.videoElement = this.getVideoElement();
-                    } else {
-                        adManagerOptions.customclickthrough = this.getClickTroughElement();
-                        this.set("customclickthrough", !!adManagerOptions.customclickthrough);
                     }
                     this.adsManager = this.auto_destroy(
                         new AdsManager(adManagerOptions, dynamics));
@@ -627,10 +629,6 @@ Scoped.define("module:Ads.Dynamics.Player", [
                     const noRepeat = !dyn.get("outstreamoptions.allowRepeat");
                     const showFirstFrameAsEndCard = dyn.get("outstreamoptions.firstframeasendcard");
                     return dyn && (showEndCard || noRepeat) && showFirstFrameAsEndCard;
-                },
-
-                getClickTroughElement: function() {
-                    return this.activeElement().querySelector('[data-selector="ba-ads-clickthrough-container"]') || null;
                 },
 
                 getAdWillAutoPlay: function() {

--- a/src/dynamics/video_player/player/player.html
+++ b/src/dynamics/video_player/player/player.html
@@ -115,7 +115,7 @@
             ba-vmapads="{{vmapads}}"
         ></ba-{{dynadsplayer}}>
         <div class="{{css}}-overlay {{hasplaceholderstyle ? (css + '-overlay-with-placeholder') : ''}}"
-             ba-show="{{!showbuiltincontroller && !outstream && !adsplaying}}" ba-styles="{{placeholderstyle}}"
+             ba-show="{{!showbuiltincontroller && !outstream && !adsplaying}}" style="{{placeholderstyle}}"
              data-testid="{{testid}}-content-player-container"
         >
             <div tabindex="-1" class="{{css}}-player-toggle-overlay" data-selector="player-toggle-overlay"

--- a/src/dynamics/video_player/player/player.html
+++ b/src/dynamics/video_player/player/player.html
@@ -115,7 +115,7 @@
             ba-vmapads="{{vmapads}}"
         ></ba-{{dynadsplayer}}>
         <div class="{{css}}-overlay {{hasplaceholderstyle ? (css + '-overlay-with-placeholder') : ''}}"
-             ba-show="{{!showbuiltincontroller && !outstream && !adsplaying}}" style="{{placeholderstyle}}"
+             ba-show="{{!showbuiltincontroller && !outstream && !adsplaying}}" ba-styles="{{placeholderstyle}}"
              data-testid="{{testid}}-content-player-container"
         >
             <div tabindex="-1" class="{{css}}-player-toggle-overlay" data-selector="player-toggle-overlay"

--- a/src/themes/_common/player/player.scss
+++ b/src/themes/_common/player/player.scss
@@ -87,7 +87,7 @@
     overflow: hidden;
 }
 
-.#{$cssvideoplayer}-overlay, {
+.#{$cssvideoplayer}-overlay {
     z-index: 1;
 }
 


### PR DESCRIPTION
## Proposed changes

- Removes custom click tracking implementation. Here is [the ticket](https://kargo1.atlassian.net/browse/ZIG-5294) if you want more info.

- Adjust how `setDisableCustomPlaybackForIOS10Plus` is getting set. As of now, this would have to be set from the `video-kargo-player` config.js file. Not sure if this is something that customers set manually but nonetheless, the config name seemed wordy and we need to call this function for mobile skippable ads anyways: https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/skippable-ads.
- I made the change in this repo but if preferred, can move it to `config.js` [here](https://github.com/KargoGlobal/video-kargo-player/blob/develop/src/player/configs.js#L46): and set a default value like:

```
"imasettings": {
    "isMobile": Info.isMobile() ? true : false
}
```


-  Fix `requestAds` always expecting `requestAdsOptions.adTagParams` to be defined.
- Small style changes


## Dependencies
- Update this if the PR requires us to update the project’s dependencies

## Checklist
- [x] Tested locally
- [ ] Added new unit, integration or regression tests
- [ ] Passed all e2e tests in local machine
- [ ] Updated docs

## Demo
- Add before and after screenshots and videos showcasing the changes
