### PR TITLE
[ZIG-5294] Add support for custom click tracking element

### DIFF
--- a/src/ads/ima/manager.js
+++ b/src/ads/ima/manager.js
@@ -16,9 +16,11 @@ Scoped.define("module:Ads.IMA.AdsManager", [
                 if (options.videoElement === null) throw Error("Missing videoElement");
                 this._options = options;
 
-                if (google && google.ima && options.IMASettings)
+                if (google && google.ima && options.IMASettings) {
                     this._setIMASettings(options);
-                this._adDisplayContainer = new google.ima.AdDisplayContainer(options.adContainer, options.videoElement);
+                }
+
+                this._adDisplayContainer = new google.ima.AdDisplayContainer(options.adContainer, options.videoElement, options.customClickthroughEl || null);
                 this._adsLoader = new google.ima.AdsLoader(this._adDisplayContainer);
                 this._adsLoader.addEventListener(google.ima.AdErrorEvent.Type.AD_ERROR, this.onAdError.bind(this), false);
                 this._adsLoader.addEventListener(google.ima.AdsManagerLoadedEvent.Type.ADS_MANAGER_LOADED, this.onAdsManagerLoaded.bind(this), false);
@@ -99,7 +101,7 @@ Scoped.define("module:Ads.IMA.AdsManager", [
                 }
 
                 // if size query param is not on the ad tag url, define them
-                if (!requestAdsOptions?.adTagParams?.sz.length > 0) {
+                if (!requestAdsOptions?.adTagParams?.sz) {
                     this._adsRequest.linearAdSlotWidth = requestAdsOptions.linearAdSlotWidth;
                     this._adsRequest.linearAdSlotHeight = requestAdsOptions.linearAdSlotHeight;
                     this._adsRequest.nonLinearAdSlotWidth = requestAdsOptions.nonLinearAdSlotWidth;

--- a/src/dynamics/ads_player/ads_player.html
+++ b/src/dynamics/ads_player/ads_player.html
@@ -64,7 +64,7 @@
     ba-userhadplayerinteraction="{{userhadplayerinteraction}}"
     ba-currenttime={{=currenttime}}
     ba-hideoninactivity={{hideoninactivity}}
-    ba-tooltips="{{tooltips}}"
+    ba-tooltips="{{isMobile ? '' : tooltips}}"
     ba-adsplaying="{{adsplaying}}"
     ba-fullscreened="{{fullscreened}}"
     ba-view_type="{{view_type}}"

--- a/src/dynamics/ads_player/ads_player.js
+++ b/src/dynamics/ads_player/ads_player.js
@@ -113,7 +113,7 @@ Scoped.define("module:Ads.Dynamics.Player", [
                     adsplaying: false,
                     companionads: [],
                     companionadcontent: null,
-                    customclickthrough: null,
+                    custom_clickthrough: null,
                     persistentcompanionad: false,
                     ads_loaded: false,
                     ads_load_started: false
@@ -255,8 +255,8 @@ Scoped.define("module:Ads.Dynamics.Player", [
                         this.set("quartile", "fourth");
                     },
                     "ads:start": function(ev) {
-                        if (this.get('customclickthrough')) {
-                            this.get('customclickthrough').style.display = 'block';
+                        if (this.get('custom_clickthrough')) {
+                            this.get('custom_clickthrough').style.display = 'block';
                         }
                         this._onStart(ev);
                         this.trackAdsPerformance(`ads-start`);
@@ -322,8 +322,8 @@ Scoped.define("module:Ads.Dynamics.Player", [
                     },
                     "ads:contentResumeRequested": function() {
                         this.set("adsplaying", false);
-                        if (this.get('customclickthrough')) {
-                            this.get('customclickthrough').style.display = 'none';
+                        if (this.get('custom_clickthrough')) {
+                            this.get('custom_clickthrough').style.display = 'none';
                         }
                     },
                     "ads:contentPauseRequested": function() {
@@ -340,7 +340,7 @@ Scoped.define("module:Ads.Dynamics.Player", [
                     const dynamics = this.parent();
                     const adContainer = this.getAdContainer();
                     const IMASettings = this.get("imasettings");
-                    const adManagerOptions = {
+                    let adManagerOptions = {
                         adContainer: adContainer,
                         adsRenderingSettings: this.get("imaadsrenderingsetting"),
                         videoElement: this.getVideoElement() || null,
@@ -349,21 +349,8 @@ Scoped.define("module:Ads.Dynamics.Player", [
 
                     if (Info.isMobile()) {
                         this.set('isMobile', true);
-
-                        if (Info.iOSversion().major >= 10) {
-                            adManagerOptions.IMASettings.iOS10Plus = true;
-                        }
-    
-                        if (IMASettings.customClickElementId) {
-                            const clickThroughEl = document.getElementById(IMASettings.customClickElementId);
-    
-                            if (clickThroughEl) {
-                                this.set('customclickthrough', clickThroughEl);
-                                adManagerOptions.customClickthroughEl = clickThroughEl;
-                            }
-                        }
+                        adManagerOptions = this.normalizeOptionsForMobile(adManagerOptions);
                     }
-
 
                     this.adsManager = this.auto_destroy(
                         new AdsManager(adManagerOptions, dynamics));
@@ -497,6 +484,22 @@ Scoped.define("module:Ads.Dynamics.Player", [
                     }
                 },
 
+                normalizeOptionsForMobile: function(adManagerOptions) {
+                    if (Info.iOSversion().major >= 10) {
+                        adManagerOptions.IMASettings.iOS10Plus = true;
+                    }
+
+                    const clickElId = adManagerOptions.IMASettings.customClickElementId;
+                    if (clickElId) {
+                        const clickThroughEl = document.getElementById(clickElId);
+
+                        if (clickThroughEl) {
+                            this.set('custom_clickthrough', clickThroughEl);
+                            adManagerOptions.customClickthroughEl = clickThroughEl;
+                        }
+                    }
+                    return adManagerOptions;
+                },
                 getAdWidth: function() {
                     if (!this.activeElement()) return null;
                     if ((this.get("sidebar_active") || (this.get("sticky") || this.get("floating"))) && this.parent()) {


### PR DESCRIPTION
## Proposed changes

- Adds support for custom click tracking element
- Adjust `sz` ad tag param check
- Show tooltips for ads only on Desktop

Demo page to test with is available in this [PR](https://github.com/KargoGlobal/video-kargo-player/pull/616) 

## Dependencies
- Update this if the PR requires us to update the project’s dependencies

## Checklist
- [ ] Tested locally
- [ ] Added new unit, integration or regression tests
- [ ] Passed all e2e tests in local machine
- [ ] Updated docs

## Demo
- Add before and after screenshots and videos showcasing the changes
