### PR TITLE
[ZIG-5370] Add manual fallback listener (longitude)

### DIFF
--- a/src/dynamics/video_player/player/states.js
+++ b/src/dynamics/video_player/player/states.js
@@ -883,7 +883,7 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PlayVideo", [
             this.listenOn(this.dyn, "error:video", function() {
                 this.next("ErrorVideo");
             }, this);
-            this.addLongitudeFallbackListener();
+            this.addManualFallbackListener();
         },
 
         getAdPosition: function() {
@@ -897,8 +897,8 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PlayVideo", [
             }
         },
 
-        addLongitudeFallbackListener: function() {
-            this.listenOn(this.dyn, "longitudeFallback", (fallbackUrl) => {
+        addManualFallbackListener: function() {
+            this.listenOn(this.dyn, "manualFallback", (fallbackUrl) => {
                 this.dyn.set('adtagurl', fallbackUrl);
                 this.dyn.scopes.adsplayer.execute(`requestAds`);
                 this.listenOnce(this.dyn.channel("ads"), "adsManagerLoaded", function() {

--- a/src/dynamics/video_player/player/states.js
+++ b/src/dynamics/video_player/player/states.js
@@ -903,7 +903,8 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PlayVideo", [
                 this.dyn.scopes.adsplayer.execute(`requestAds`);
                 this.listenOnce(this.dyn.channel("ads"), "adsManagerLoaded", function() {
                     this.next("LoadAds", {
-                        position: this.getAdPosition()
+                        position: this.getAdPosition(),
+                        autoplay: true
                     });
                 });
             }, this);

--- a/src/dynamics/video_player/player/states.js
+++ b/src/dynamics/video_player/player/states.js
@@ -839,18 +839,10 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PlayVideo", [
             }
             this.listenOn(this.dyn.channel("ads"), "contentPauseRequested", function() {
                 this.dyn.pause();
-                var position = this.dyn.getCurrentPosition();
-                if (position === 0) {
-                    this.next("PrerollAd");
-                } else {
-                    if (Math.abs(this.dyn.getCurrentPosition() - this.dyn.get("duration")) < 0.1) {
-                        this.next("PostrollAd");
-                    } else {
-                        if (this.dyn.get("duration") > this.dyn.get("max_shortform_video_duration")) {
-                            this.next("MidrollAd")
-                        }
-                    };
-                }
+                const position = this.getAdPosition();
+                // Uppercase the returned ad break type value
+                const adBreak = position.charAt(0).toUpperCase() + position.slice(1) + "rollAd";
+                this.next(adBreak);
             }, this);
             this.listenOn(this.dyn, "playnextmidroll", function() {
                 if (!this.dyn.get("adsplayer_active")) {
@@ -890,6 +882,30 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PlayVideo", [
             }, this);
             this.listenOn(this.dyn, "error:video", function() {
                 this.next("ErrorVideo");
+            }, this);
+            this.addLongitudeFallbackListener();
+        },
+
+        getAdPosition: function() {
+            const currentPosition = this.dyn.getCurrentPosition();
+            if (currentPosition === 0) {
+                return State.ADS_POSITIONS.PREROLL
+            } else if (Math.abs(currentPosition - this.dyn.get("duration")) < 0.1) {
+                return State.ADS_POSITIONS.POSTROLL
+            } else {
+                return State.ADS_POSITIONS.MIDROLL
+            }
+        },
+
+        addLongitudeFallbackListener: function() {
+            this.listenOn(this.dyn, "longitudeFallback", (fallbackUrl) => {
+                this.dyn.set('adtagurl', fallbackUrl);
+                this.dyn.scopes.adsplayer.execute(`requestAds`);
+                this.listenOnce(this.dyn.channel("ads"), "adsManagerLoaded", function() {
+                    this.next("LoadAds", {
+                        position: this.getAdPosition()
+                    });
+                });
             }, this);
         },
 


### PR DESCRIPTION
## Proposed changes
- Adds a listener for `manualFallback` event. This is for our Longitude implementation specifically but the event is setup so it can be called outside of the Longitude implementation as well. 

Also review: https://github.com/KargoGlobal/video-kargo-player/pull/657

## Dependencies
- Update this if the PR requires us to update the project’s dependencies

## Checklist
- [ ] Tested locally
- [ ] Added new unit, integration or regression tests
- [ ] Passed all e2e tests in local machine
- [ ] Updated docs

## Demo
- Add before and after screenshots and videos showcasing the changes
