### PR TITLE
[ZIG-5429] Address VPAID unmuting player during playback

### DIFF
--- a/src/dynamics/ads_player/ads_player.js
+++ b/src/dynamics/ads_player/ads_player.js
@@ -249,6 +249,10 @@ Scoped.define("module:Ads.Dynamics.Player", [
                         this._onStart(ev);
                         this.trackAdsPerformance(`ads-start`);
                         this.set(`ads_loaded`, false);
+                        // Mute again to prevent edge case with VPAID creatives unmuting the player and not synching with IMA SDK.
+                        if (this.get('muted') || this.get('volume') === 0) {
+                            this.adsManager.setVolume(0);
+                        }
                     },
                     "ads:skippableStateChanged": function(event) {
                         this.set("skipvisible", true);


### PR DESCRIPTION
## Proposed changes
- Adds a check to make sure player is muted on `start`. VPAID creatives sometimes has syncing issues with content on start.

## Dependencies
- Update this if the PR requires us to update the project’s dependencies

## Checklist
- [ ] Tested locally
- [ ] Added new unit, integration or regression tests
- [ ] Passed all e2e tests in local machine
- [ ] Updated docs

## Demo
- Add before and after screenshots and videos showcasing the changes
