### PR TITLE
[ZIG-5398] Outstream improvements

### DIFF
--- a/src/dynamics/ads_player/ads_player.js
+++ b/src/dynamics/ads_player/ads_player.js
@@ -208,11 +208,18 @@ Scoped.define("module:Ads.Dynamics.Player", [
                 },
 
                 channels: {
+                    "ads:impression": function() {
+                        if (this.parent()?.get("outstream")) {
+                            // On ad impression, reset the retry on ad-error count.
+                            this.parent().resetOutstreamRetries();
+                        }
+                    },
                     "ads:ad-error": function() {
                         this.set(`adsplaying`, false);
                         this.set(`ads_loaded`, false);
                         this.set(`ads_load_started`, false);
                         if (this.parent()?.get("outstream")) {
+                            this.parent().trackOutstreamRetries();
                             this.parent().hidePlayerContainer();
                         }
                         this.trackAdsPerformance(`ad-error`);
@@ -969,7 +976,7 @@ Scoped.define("module:Ads.Dynamics.Player", [
                     if (Types.is_undefined(dyn.activeElement))
                         throw Error("Wrong dynamics instance was provided to _hideContentPlayer");
                     this._hideCompanionAd();
-                    dyn.hidePlayerContainer();
+                    dyn.hidePlayerContainer(true);
                     // dyn.weakDestroy(); // << Create will not work as expected
                 },
 

--- a/src/dynamics/ads_player/ads_player.js
+++ b/src/dynamics/ads_player/ads_player.js
@@ -212,7 +212,7 @@ Scoped.define("module:Ads.Dynamics.Player", [
                         this.set(`adsplaying`, false);
                         this.set(`ads_loaded`, false);
                         this.set(`ads_load_started`, false);
-                        if (this.parent().get("outstream")) {
+                        if (this.parent()?.get("outstream")) {
                             this.parent().hidePlayerContainer();
                         }
                         this.trackAdsPerformance(`ad-error`);
@@ -655,7 +655,9 @@ Scoped.define("module:Ads.Dynamics.Player", [
                 },
 
                 trackAdsPerformance: function(name) {
-                    this.parent()._recordPerformance(name);
+                    if (this.parent()) {
+                        this.parent()._recordPerformance(name);
+                    }
                 },
 
                 _onStart: function(ev) {

--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -901,6 +901,13 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                         styles = {
                             aspectRatio: aspectRatio
                         };
+
+                        // Outstream should not have a side bar and should always be floating.
+                        if (outstream) {
+                            this.set("floatingoptions.floatingonly", true);
+                            this.set("floatingoptions.sidebar", false);
+                        }
+
                         if (!fullscreened && gallerySidebar) styles.aspectRatio = this.get("sidebaroptions.aspectratio") || 838 / 360;
                         if (height) styles.height = isNaN(height) ? height : parseFloat(height).toFixed(2) + "px";
                         if (width) styles.width = isNaN(width) ? width : parseFloat(width).toFixed(2) + "px";

--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -666,9 +666,9 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
 
                             if (this.get("duration") >= minDurationNext && showNextTime && position > showNextTime && !this.get("next_active")) {
                                 this.set("next_active", true);
-                            }        
-                            
-                            
+                            }
+
+
                             if (this.get("duration") >= minDurationNext && position > engageTime && engageTime > 0) {
                                 this.channel("next").trigger("autoPlayNext");
                                 this.channel("next").trigger("playNext", true);
@@ -2647,6 +2647,12 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                     if ((this.get("nextadtagurls") && this.get("nextadtagurls").length > 0) || (this.get("adtagurlfallbacks") && this.get("adtagurlfallbacks").length > 0)) {
                         promise.asyncSuccess(this.get("nextadtagurls").length > 0 ? this.get("nextadtagurls").shift() : this.get("adtagurlfallbacks").shift());
                     } else {
+                        const requestInterval = this.get("outstreamoptions.recurrenceperiod");
+
+                        if (requestInterval === 0) {
+                            immediate = true;
+                        }
+
                         Async.eventually(function() {
                             var _promise = this.requestForTheNextAdTagURL();
                             var isGlobalPromise = typeof _promise.then === "function";
@@ -2657,7 +2663,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                                     return promise.asyncError(error);
                                 }, this) :
                                 console.log("Please define requestForTheNextAdTagURL method with Promise.");
-                        }, this, immediate ? 100 : this.get("outstreamoptions.recurrenceperiod") || 30000);
+                        }, this, immediate ? 100 : requestInterval || 30000);
                     }
                     return promise;
                 },

--- a/src/dynamics/video_player/player/states.js
+++ b/src/dynamics/video_player/player/states.js
@@ -696,7 +696,7 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PlayOutstream", [
             }
 
             // Return early to prevent outstream player from hiding/re-appearing.
-            if (this.dyn.get('outstreamoptions.recurrenceperiod') === 0) {
+            if (this.dyn.get('outstreamoptions.recurrenceperiod') === 0 && !this.dyn.get("maxRetriesMet")) {
                 this.dyn.set('adsplayer_active', false);
                 return;
             }

--- a/src/dynamics/video_player/player/states.js
+++ b/src/dynamics/video_player/player/states.js
@@ -696,7 +696,7 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PlayOutstream", [
             }
 
             // Return early to prevent outstream player from hiding/re-appearing.
-            if (this.dyn.get('outstreamoptions.recurrenceperiod') === 0 && !this.dyn.get("maxRetriesMet")) {
+            if (this.dyn.get('outstreamoptions.recurrenceperiod') === 0 && this.dyn.get("availableOutstreamRetries")) {
                 this.dyn.set('adsplayer_active', false);
                 return;
             }

--- a/src/dynamics/video_player/player/states.js
+++ b/src/dynamics/video_player/player/states.js
@@ -694,6 +694,13 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PlayOutstream", [
             } else {
                 if (this.dyn.get("outstreamoptions.hideOnCompletion")) this.dyn.hidePlayerContainer();
             }
+
+            // Return early to prevent outstream player from hiding/re-appearing.
+            if (this.dyn.get('outstreamoptions.recurrenceperiod') === 0) {
+                this.dyn.set('adsplayer_active', false);
+                return;
+            }
+
             this.dyn.trigger("outstream-completed");
             // Somehow below code is running even this.dyn is undefined and this states checked in the above statement
             if (this.dyn) this.dyn.channel("ads").trigger("outstreamCompleted", this.dyn);


### PR DESCRIPTION
## Proposed changes
- Fixes a bug with outstream player crashing on `ad-error`
- Add logic to make the outstream player immediately request ads and not hide itself
- Add logic + config to retry ads on ad-error
- Make outstream always float with no sidebar

## Dependencies
- Update this if the PR requires us to update the project’s dependencies

## Checklist
- [ ] Tested locally
- [ ] Added new unit, integration or regression tests
- [ ] Passed all e2e tests in local machine
- [ ] Updated docs

## Demo
- Add before and after screenshots and videos showcasing the changes
