### PR TITLE
[ZIG-5453] Remove duplicate outstream cleanup logic

### DIFF
--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -902,12 +902,6 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                             aspectRatio: aspectRatio
                         };
 
-                        // Outstream should not have a side bar and should always be floating.
-                        if (outstream) {
-                            this.set("floatingoptions.floatingonly", true);
-                            this.set("floatingoptions.sidebar", false);
-                        }
-
                         if (!fullscreened && gallerySidebar) styles.aspectRatio = this.get("sidebaroptions.aspectratio") || 838 / 360;
                         if (height) styles.height = isNaN(height) ? height : parseFloat(height).toFixed(2) + "px";
                         if (width) styles.width = isNaN(width) ? width : parseFloat(width).toFixed(2) + "px";


### PR DESCRIPTION
## Proposed changes
- Remove redundant logic for forcing outstream to always float with no side bar as it is [handled](https://github.com/KargoGlobal/video-kargo-player/pull/671) in `video-kargo-player` now.

## Dependencies
- Update this if the PR requires us to update the project’s dependencies

## Checklist
- [ ] Tested locally
- [ ] Added new unit, integration or regression tests
- [ ] Passed all e2e tests in local machine
- [ ] Updated docs

## Demo
- Add before and after screenshots and videos showcasing the changes
