### PR TITLE
[ZIG-5398] Refactor ad retry logic for outstream

### DIFF
--- a/src/dynamics/ads_player/ads_player.js
+++ b/src/dynamics/ads_player/ads_player.js
@@ -210,8 +210,7 @@ Scoped.define("module:Ads.Dynamics.Player", [
                 channels: {
                     "ads:impression": function() {
                         if (this.parent()?.get("outstream")) {
-                            // On ad impression, reset the retry on ad-error count.
-                            this.parent().resetOutstreamRetries();
+                            this.parent().handleOutstreamAdImpression();
                         }
                     },
                     "ads:ad-error": function() {
@@ -219,8 +218,7 @@ Scoped.define("module:Ads.Dynamics.Player", [
                         this.set(`ads_loaded`, false);
                         this.set(`ads_load_started`, false);
                         if (this.parent()?.get("outstream")) {
-                            this.parent().trackOutstreamRetries();
-                            this.parent().hidePlayerContainer();
+                            this.parent().handleOutstreamAdError();
                         }
                         this.trackAdsPerformance(`ad-error`);
                     },

--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -2676,7 +2676,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                                     return promise.asyncError(error);
                                 }, this) :
                                 console.log("Please define requestForTheNextAdTagURL method with Promise.");
-                        }, this, immediate ? 100 : this.get("outstreamoptions.recurrenceperiod") || 5000);
+                        }, this, immediate ? 100 : this.get("outstreamoptions.recurrenceperiod") || 30000);
                     }
                     return promise;
                 },
@@ -2688,7 +2688,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                         this.set("availableOutstreamRetries", this.get("outstreamoptions.numOfRetriesOnError") || 0);
                     } else {
                         // Manually trigger a non-immediate ad request when we toggle to false.
-                        this.trigger("outstreamErrorRetry");
+                        this.trigger("outstreamRetryWithInterval");
                     }
                 },
 
@@ -2712,7 +2712,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                             this.setImmediateOutstreamRequests(false);
                         }
                     } else if (immediateRequestEnabled === false) {
-                        this.trigger("outstreamErrorRetry");
+                        this.trigger("outstreamRetryWithInterval");
                     }
 
                     this.hidePlayerContainer();

--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -2683,20 +2683,14 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
 
                 setImmediateOutstreamRequests(value) {
                     this.set("immediateOutstreamRequests", value);
-
-                    if (value) {
-                        this.set("availableOutstreamRetries", this.get("outstreamoptions.numOfRetriesOnError") || 0);
-                    } else {
-                        // Manually trigger a non-immediate ad request when we toggle to false.
-                        this.trigger("outstreamRetryOnInterval");
-                    }
                 },
 
                 handleOutstreamAdImpression() {
                     const immediateRequests = this.get("immediateOutstreamRequests");
-                    // Reset `availableOutstreamRetries` for immediate outstream requests.
                     if (immediateRequests !== undefined) {
                         this.setImmediateOutstreamRequests(true);
+                        // Reset number of available retries for immediate outstream requests.
+                        this.set("availableOutstreamRetries", this.get("outstreamoptions.numOfRetriesOnError") || 0);
                     }
                 },
 
@@ -2711,7 +2705,10 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                         } else {
                             this.setImmediateOutstreamRequests(false);
                         }
-                    } else if (immediateRequestEnabled === false) {
+                    }
+
+                    // Trigger a non-immediate manual retry using on ad-error if `immediateOutstreamRequests` was toggled to false.
+                    if (this.get("immediateOutstreamRequests") === false) {
                         this.trigger("outstreamRetryOnInterval");
                     }
 

--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -2688,7 +2688,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                         this.set("availableOutstreamRetries", this.get("outstreamoptions.numOfRetriesOnError") || 0);
                     } else {
                         // Manually trigger a non-immediate ad request when we toggle to false.
-                        this.trigger("outstreamRetryWithInterval");
+                        this.trigger("outstreamRetryOnInterval");
                     }
                 },
 
@@ -2712,7 +2712,7 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                             this.setImmediateOutstreamRequests(false);
                         }
                     } else if (immediateRequestEnabled === false) {
-                        this.trigger("outstreamRetryWithInterval");
+                        this.trigger("outstreamRetryOnInterval");
                     }
 
                     this.hidePlayerContainer();

--- a/src/dynamics/video_player/player/states.js
+++ b/src/dynamics/video_player/player/states.js
@@ -656,6 +656,8 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PlayOutstream", [
         dynamics: ["adscontrolbar"],
 
         _started: function() {
+            // When we have multiple bad ads while attempting fallback, the player will show up with a black screen with no ad content.
+            // So listen on `impression` before showing the player.
             this.listenOn(this.dyn.channel("ads"), "impression", function() {
                 // if player is not hidden below method will do nothing
                 this.dyn.showHiddenPlayerContainer();

--- a/src/dynamics/video_player/player/states.js
+++ b/src/dynamics/video_player/player/states.js
@@ -664,6 +664,10 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PlayOutstream", [
 
             this.dyn.channel("ads").trigger("outstreamStarted", this.dyn);
 
+            this.listenOn(this.dyn, "outstreamErrorRetry", function() {
+                this.dyn.setNextOutstreamAdTagURL(false, this, "LoadPlayer");
+            });
+
             this.listenOn(this.dyn.channel("ads"), "allAdsCompleted", function() {
                 this.afterAdCompleted();
             }, this);
@@ -696,7 +700,7 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PlayOutstream", [
             }
 
             // Return early to prevent outstream player from hiding/re-appearing.
-            if (this.dyn.get('outstreamoptions.recurrenceperiod') === 0 && this.dyn.get("availableOutstreamRetries")) {
+            if (this.dyn.get('immediateOutstreamRequests')) {
                 this.dyn.set('adsplayer_active', false);
                 return;
             }

--- a/src/dynamics/video_player/player/states.js
+++ b/src/dynamics/video_player/player/states.js
@@ -664,8 +664,8 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PlayOutstream", [
 
             this.dyn.channel("ads").trigger("outstreamStarted", this.dyn);
 
-            // When we run out of ad retries with immediate requests, we manually trigger `outstreamRetryWithInterval` to use `recurrenceperiod`.
-            this.listenOn(this.dyn, "outstreamRetryWithInterval", function() {
+            // When we run out of ad retries with immediate requests, we manually trigger `outstreamRetryOnInterval` to use `recurrenceperiod`.
+            this.listenOn(this.dyn, "outstreamRetryOnInterval", function() {
                 this.dyn.setNextOutstreamAdTagURL(false, this, "LoadPlayer");
             });
 

--- a/src/dynamics/video_player/player/states.js
+++ b/src/dynamics/video_player/player/states.js
@@ -657,8 +657,8 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PlayOutstream", [
 
         _started: function() {
             // When we have multiple bad ads while attempting fallback, the player will show up with a black screen with no ad content.
-            // So listen on `impression` before showing the player.
-            this.listenOn(this.dyn.channel("ads"), "impression", function() {
+            // So listen on `adCanPlay` before showing the player.
+            this.listenOn(this.dyn.channel("ads"), "adCanPlay", function() {
                 // if player is not hidden below method will do nothing
                 this.dyn.showHiddenPlayerContainer();
             });

--- a/src/dynamics/video_player/player/states.js
+++ b/src/dynamics/video_player/player/states.js
@@ -656,8 +656,10 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PlayOutstream", [
         dynamics: ["adscontrolbar"],
 
         _started: function() {
-            // if player is not hidden below method will do nothing
-            this.dyn.showHiddenPlayerContainer();
+            this.listenOn(this.dyn.channel("ads"), "impression", function() {
+                // if player is not hidden below method will do nothing
+                this.dyn.showHiddenPlayerContainer();
+            });
 
             const floating = this.dyn.get("sticky") || this.dyn.get("floating");
             if (floating && this.dyn.floatHandler) this.dyn.floatHandler.start();

--- a/src/dynamics/video_player/player/states.js
+++ b/src/dynamics/video_player/player/states.js
@@ -664,7 +664,8 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PlayOutstream", [
 
             this.dyn.channel("ads").trigger("outstreamStarted", this.dyn);
 
-            this.listenOn(this.dyn, "outstreamErrorRetry", function() {
+            // When we run out of ad retries with immediate requests, we manually trigger `outstreamRetryWithInterval` to use `recurrenceperiod`.
+            this.listenOn(this.dyn, "outstreamRetryWithInterval", function() {
                 this.dyn.setNextOutstreamAdTagURL(false, this, "LoadPlayer");
             });
 


### PR DESCRIPTION
## Proposed changes
- Had to refactor since `numOfRetriesOnError` set to 0 would not make ad requests immediate.

## Dependencies
- Update this if the PR requires us to update the project’s dependencies

## Checklist
- [ ] Tested locally
- [ ] Added new unit, integration or regression tests
- [ ] Passed all e2e tests in local machine
- [ ] Updated docs

## Demo
- Add before and after screenshots and videos showcasing the changes
