### PR TITLE
[ZIG-5613] Remove hidePlayerContainer on ad-error

### DIFF
--- a/src/dynamics/video_player/player/player.js
+++ b/src/dynamics/video_player/player/player.js
@@ -2720,8 +2720,8 @@ Scoped.define("module:VideoPlayer.Dynamics.Player", [
                         }
                     }
 
-                    // Trigger a non-immediate manual retry using on ad-error if `immediateOutstreamRequests` was toggled to false.
-                    if (this.get("immediateOutstreamRequests") === false) {
+                    // Trigger a non-immediate manual retry using on ad-error
+                    if (!this.get("immediateOutstreamRequests")) {
                         this.trigger("outstreamRetryOnInterval");
                     }
 

--- a/src/dynamics/video_player/player/states.js
+++ b/src/dynamics/video_player/player/states.js
@@ -481,12 +481,10 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.Outstream", [
 
             this.listenOn(this.dyn.channel("ads"), "ad-error", function() {
                 if (this.dyn.get("outstream")) {
-                    this.dyn.hidePlayerContainer();
                     if ((this.dyn.get("nextadtagurls") && this.dyn.get("nextadtagurls").length > 0)) {
                         this.dyn.set("adtagurl", this.dyn.get("nextadtagurls").shift());
                         this.dyn.scopes.adsplayer.execute("requestAds");
                     } else {
-                        this.dyn.set("immediateOutstreamRequests", false)
                         this.dyn.setNextOutstreamAdTagURL(false, this);
                     }
                 } else {
@@ -937,7 +935,7 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.PlayAd", [
                         this.pause();
                     }, this);
                 }
-               
+
                 this.listenOn(this.dyn.channel("ads"), "contentResumeRequested", function() {
                     this.resume();
                 }, this);

--- a/src/dynamics/video_player/player/states.js
+++ b/src/dynamics/video_player/player/states.js
@@ -485,6 +485,7 @@ Scoped.define("module:VideoPlayer.Dynamics.PlayerStates.Outstream", [
                         this.dyn.set("adtagurl", this.dyn.get("nextadtagurls").shift());
                         this.dyn.scopes.adsplayer.execute("requestAds");
                     } else {
+                        this.dyn.set("immediateOutstreamRequests", false)
                         this.dyn.setNextOutstreamAdTagURL(false, this);
                     }
                 } else {


### PR DESCRIPTION
## Proposed changes
- Remove call to `hidePlayerContainer` in ad-error since the player gets hidden anyway. The extra call seemed to cause some side effects which resulted in the error shown in the ZIG ticket

## Dependencies
- Update this if the PR requires us to update the project’s dependencies

## Checklist
- [ ] Tested locally
- [ ] Added new unit, integration or regression tests
- [ ] Passed all e2e tests in local machine
- [ ] Updated docs

## Demo
- Add before and after screenshots and videos showcasing the changes
